### PR TITLE
Fix map handling and activity update

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -74,10 +74,12 @@ class ActivityController extends Controller
     public function update(Request $request, Activity $activity)
     {
         $validated = $request->validate([
-            'title' => 'required|string|max:255',
-            'location' => 'nullable|string|max:255',
+            'title'        => 'required|string|max:255',
+            'location'     => 'nullable|string|max:255',
             'scheduled_at' => 'required|date',
-            'note' => 'nullable|string',
+            'note'         => 'nullable|string',
+            'latitude'     => 'nullable|numeric',
+            'longitude'    => 'nullable|numeric',
         ]);
 
         $activity->update($validated);

--- a/resources/views/activity/activity-form.blade.php
+++ b/resources/views/activity/activity-form.blade.php
@@ -71,6 +71,8 @@
                         const lng = parseFloat(($refs.lng.value || 125.17));
 
                         const map = L.map($el).setView([lat, lng], 13);
+                        // ensure proper sizing when modal becomes visible
+                        setTimeout(() => map.invalidateSize(), 0);
                         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                             attribution: '© OpenStreetMap contributors'
                         }).addTo(map);
@@ -100,6 +102,9 @@
                             $refs.lat.value = lt.toFixed(7);
                             $refs.lng.value = lg.toFixed(7);
                         });
+
+                        $watch('openActivityForm', value => { if (value) setTimeout(() => map.invalidateSize(), 0); });
+                        $watch('openEditModal',   value => { if (value) setTimeout(() => map.invalidateSize(), 0); });
 
                         $el.dataset.loaded = true;
                      }"


### PR DESCRIPTION
## Summary
- ensure latitude/longitude update when editing activities
- improve map initialization sizing in activity form

## Testing
- `php -l app/Http/Controllers/ActivityController.php`
- `php -l resources/views/activity/activity-form.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_688c32f827b08329bbc86c09955104c5