### PR TITLE
Fix activity pin and allow itinerary editing

### DIFF
--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -14,7 +14,11 @@ class ItineraryController extends Controller
      */
     public function index()
     {
-        //
+        $itineraries = Itinerary::with('activities')
+            ->where('user_id', Auth::id())
+            ->get();
+
+        return view('dashboard', compact('itineraries'));
     }
 
     /**
@@ -54,7 +58,11 @@ class ItineraryController extends Controller
      */
     public function show(string $id)
     {
-        //
+        $itinerary = Itinerary::with('activities')
+            ->where('user_id', Auth::id())
+            ->findOrFail($id);
+
+        return view('itineraries.show', compact('itinerary'));
     }
 
     /**
@@ -62,7 +70,8 @@ class ItineraryController extends Controller
      */
     public function edit(string $id)
     {
-        //
+        $itinerary = Itinerary::where('user_id', Auth::id())->findOrFail($id);
+        return view('itineraries.edit', compact('itinerary'));
     }
 
     /**
@@ -70,7 +79,18 @@ class ItineraryController extends Controller
      */
     public function update(Request $request, string $id)
     {
-        //
+        $itinerary = Itinerary::where('user_id', Auth::id())->findOrFail($id);
+
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after_or_equal:start_date',
+        ]);
+
+        $itinerary->update($validated);
+
+        return redirect()->route('dashboard')->with('success', 'Itinerary updated.');
     }
 
     /**
@@ -78,6 +98,9 @@ class ItineraryController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $itinerary = Itinerary::where('user_id', Auth::id())->findOrFail($id);
+        $itinerary->delete();
+
+        return redirect()->route('dashboard')->with('success', 'Itinerary deleted.');
     }
 }

--- a/resources/views/components/itinerary-card.blade.php
+++ b/resources/views/components/itinerary-card.blade.php
@@ -18,6 +18,16 @@
         <p class="text-sm text-gray-500 dark:text-gray-400">
             {{ $itinerary->start_date }} to {{ $itinerary->end_date }}
         </p>
+
+        <div class="mt-2 flex items-center gap-2 text-sm">
+            <a href="{{ route('itineraries.edit', $itinerary->id) }}" class="text-indigo-600 hover:underline">Edit</a>
+
+            <form method="POST" action="{{ route('itineraries.destroy', $itinerary->id) }}" onsubmit="return confirm('Delete this itinerary?')">
+                @csrf
+                @method('DELETE')
+                <button type="submit" class="text-red-600 hover:underline">Delete</button>
+            </form>
+        </div>
     </div>
 
     <!-- ── Activities List ──────────────────────────────────────────── -->
@@ -54,33 +64,5 @@
         <x-itinerary-map :activities="$itinerary->activities" />
     </div>
 
-    <!-- ── Leaflet “drop-pin” helper (only used by add-form) ────────── -->
-    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
-    <script>
-        document.addEventListener('alpine:init', () => {
-            Alpine.effect(() => {
-                Alpine.nextTick(() => {
-                    const mapContainer = document.getElementById('drop-pin-map');
-                    if (mapContainer && !mapContainer.dataset.mapInitialized) {
-                        mapContainer.dataset.mapInitialized = true;
-
-                        const map = L.map('drop-pin-map').setView([6.11, 125.17], 13);
-                        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                            attribution: '&copy; OpenStreetMap contributors'
-                        }).addTo(map);
-
-                        let marker;
-                        map.on('click', e => {
-                            const { lat, lng } = e.latlng;
-                            document.getElementById('latitude').value = lat.toFixed(7);
-                            document.getElementById('longitude').value = lng.toFixed(7);
-
-                            if (marker) marker.setLatLng(e.latlng);
-                            else marker = L.marker(e.latlng).addTo(map);
-                        });
-                    }
-                });
-            });
-        });
-    </script>
 </div>
+

--- a/resources/views/itineraries/edit.blade.php
+++ b/resources/views/itineraries/edit.blade.php
@@ -1,0 +1,41 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Edit Itinerary') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-10 max-w-2xl mx-auto sm:px-6 lg:px-8">
+        <form method="POST" action="{{ route('itineraries.update', $itinerary->id) }}">
+            @csrf
+            @method('PUT')
+
+            <div class="mb-4">
+                <label for="title" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Title</label>
+                <input type="text" name="title" id="title" required value="{{ old('title', $itinerary->title) }}"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+            </div>
+
+            <div class="mb-4">
+                <label for="description" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Description</label>
+                <textarea name="description" id="description" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white">{{ old('description', $itinerary->description) }}</textarea>
+            </div>
+
+            <div class="mb-4">
+                <label for="start_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Start Date</label>
+                <input type="date" name="start_date" id="start_date" required value="{{ old('start_date', $itinerary->start_date) }}"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+            </div>
+
+            <div class="mb-4">
+                <label for="end_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">End Date</label>
+                <input type="date" name="end_date" id="end_date" required value="{{ old('end_date', $itinerary->end_date) }}"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+            </div>
+
+            <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded shadow">
+                Update Itinerary
+            </button>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -1,0 +1,11 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ $itinerary->title }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <x-itinerary-card :itinerary="$itinerary" />
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## Summary
- fix leaflet "drop pin" initialization
- implement full CRUD actions for itineraries
- add edit & delete buttons to itinerary card
- add views for editing and viewing itineraries

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_688c35f7a2f883298f6dcf9800165165