### PR TITLE
Fix Leaflet and add theme toggle

### DIFF
--- a/resources/views/components/itinerary-map.blade.php
+++ b/resources/views/components/itinerary-map.blade.php
@@ -1,44 +1,46 @@
 @props(['activities'])
+@php
+    $mapId = 'itinerary-map-' . uniqid();
+@endphp
 
-<div id="itinerary-map" class="h-80 w-full rounded-lg shadow"></div>
+<div id="{{ $mapId }}" class="h-80 w-full rounded-lg shadow"></div>
 
 @push('scripts')
-<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-    const map = L.map('itinerary-map').setView([6.11, 125.17], 11);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-        { attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
+    const lightUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    const darkUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+    const isDark = document.documentElement.classList.contains('dark');
+    const map = L.map(@js($mapId)).setView([6.11, 125.17], 11);
+    let tileLayer = L.tileLayer(isDark ? darkUrl : lightUrl, { attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
 
     const markers   = {};
     const pathCoords = [];
 
     @foreach($activities->sortBy('scheduled_at') as $act)
         @if($act->latitude && $act->longitude)
-            const m{{ $act->id }} = L.marker(
-                [{{ $act->latitude }}, {{ $act->longitude }}],
-                { title: "{{ $act->title }}" }
-            )
+            const m{{ $act->id }} = L.marker([
+                {{ $act->latitude }}, {{ $act->longitude }}
+            ], { title: "{{ $act->title }}" })
             .bindPopup(`<strong>{{ $act->title }}</strong><br>{{ $act->location ?? '' }}`)
             .addTo(map);
-
             markers['marker-{{ $act->id }}'] = m{{ $act->id }};
             pathCoords.push([{{ $act->latitude }}, {{ $act->longitude }}]);
         @endif
     @endforeach
 
     if (pathCoords.length > 1){
-        const line = L.polyline(pathCoords, {color:'blue'}).addTo(map);
+        const line = L.polyline(pathCoords, {color:'#2563eb'}).addTo(map);
         map.fitBounds(line.getBounds(), {padding:[20,20]});
     } else if (pathCoords.length === 1){
         map.setView(pathCoords[0], 13);
     }
 
-    // expose helpers for list component
     window.highlightMarker = id => {
         if(markers[id]) {
             markers[id].setIcon(
-                L.icon({iconUrl:'https://unpkg.com/leaflet@1.9.3/dist/images/marker-icon-2x.png',
+                L.icon({iconUrl:'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/images/marker-icon-2x.png',
                         iconSize:[25,41], iconAnchor:[12,41], className:'ring-2 ring-yellow-400'})
             );
             map.panTo(markers[id].getLatLng());
@@ -52,6 +54,11 @@ document.addEventListener('DOMContentLoaded', () => {
     window.openPopup = id => {
         if(markers[id]) { markers[id].openPopup(); }
     };
+
+    document.addEventListener('theme-changed', () => {
+        const url = document.documentElement.classList.contains('dark') ? darkUrl : lightUrl;
+        tileLayer.setUrl(url);
+    });
 });
 </script>
 @endpush

--- a/resources/views/components/theme-toggle.blade.php
+++ b/resources/views/components/theme-toggle.blade.php
@@ -1,26 +1,32 @@
-<button
-    id="theme-toggle"
-    class="absolute top-6 right-6 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-white px-3 py-2 rounded-md shadow hover:bg-gray-300 dark:hover:bg-gray-600 transition"
-    aria-label="Toggle Dark Mode"
->
-    <span id="theme-toggle-text">🌞 Light</span>
+@php
+    $toggleId = 'theme-toggle-' . uniqid();
+    $thumbId = $toggleId . '-thumb';
+@endphp
+<button id="{{ $toggleId }}" aria-label="Toggle Dark Mode"
+    class="relative inline-flex h-8 w-14 items-center rounded-full bg-gray-300 dark:bg-gray-700 transition-colors focus:outline-none">
+    <span class="absolute left-1 text-yellow-500 text-sm">🌞</span>
+    <span class="absolute right-1 text-gray-200 text-sm">🌙</span>
+    <span id="{{ $thumbId }}" class="inline-block h-6 w-6 transform rounded-full bg-white shadow transition"></span>
 </button>
 
 <script>
     document.addEventListener('DOMContentLoaded', function () {
-        const button = document.getElementById('theme-toggle');
-        const text = document.getElementById('theme-toggle-text');
+        const button = document.getElementById(@js($toggleId));
+        const thumb = document.getElementById(@js($thumbId));
 
-        // Apply saved theme
-        if (localStorage.getItem('theme') === 'dark') {
-            document.documentElement.classList.add('dark');
-            text.textContent = '🌙 Dark';
+        function applyTheme(isDark) {
+            document.documentElement.classList.toggle('dark', isDark);
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            thumb.classList.toggle('translate-x-6', isDark);
         }
 
+        let isDark = localStorage.getItem('theme') === 'dark';
+        applyTheme(isDark);
+
         button.addEventListener('click', () => {
-            const isDark = document.documentElement.classList.toggle('dark');
-            localStorage.setItem('theme', isDark ? 'dark' : 'light');
-            text.textContent = isDark ? '🌙 Dark' : '🌞 Light';
+            isDark = !isDark;
+            applyTheme(isDark);
+            document.dispatchEvent(new Event('theme-changed'));
         });
     });
 </script>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -69,36 +69,5 @@
         @endforeach
     </div>
 
-    {{-- Leaflet Map --}}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            @foreach ($itineraries as $itinerary)
-                const coords{{ $itinerary->id }} = {!! json_encode($itinerary->coordinates ?? []) !!};
-                if (coords{{ $itinerary->id }}.length > 0) {
-                    const map = L.map('map-itinerary-{{ $itinerary->id }}').setView(
-                        [coords{{ $itinerary->id }}[0].lat, coords{{ $itinerary->id }}[0].lng], 13);
-
-                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                        attribution: '&copy; OpenStreetMap contributors'
-                    }).addTo(map);
-
-                    const latlngs = [];
-
-                    coords{{ $itinerary->id }}.forEach(point => {
-                        L.marker([point.lat, point.lng])
-                            .addTo(map)
-                            .bindPopup(`<strong>${point.title}</strong><br>${point.location}`);
-                        latlngs.push([point.lat, point.lng]);
-                    });
-
-                    // Draw path line
-                    L.polyline(latlngs, { color: 'blue' }).addTo(map);
-                    map.fitBounds(L.polyline(latlngs).getBounds());
-                }
-            @endforeach
-    });
-    </script>
 
 </x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -48,7 +48,7 @@
 
 </body>
 <script src="//unpkg.com/alpinejs" defer></script>
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
-<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js" defer></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" />
+
 
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -18,6 +18,11 @@
                 </div>
             </div>
 
+            <!-- Theme Toggle -->
+            <div class="hidden sm:flex sm:items-center sm:ms-6">
+                <x-theme-toggle />
+            </div>
+
             <!-- Settings Dropdown -->
             <div class="hidden sm:flex sm:items-center sm:ms-6">
                 <x-dropdown align="right" width="48">
@@ -70,6 +75,9 @@
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
+            <div class="px-4 pt-2">
+                <x-theme-toggle />
+            </div>
         </div>
 
         <!-- Responsive Settings Options -->


### PR DESCRIPTION
## Summary
- improve theme toggle style and support multiple instances
- update itinerary map with dark mode tiles and unique IDs
- remove old Leaflet script from dashboard and update layout assets
- expose theme switch in navigation for all pages

## Testing
- `composer test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c414d68e0832990a9536dc2c496fe