### PR TITLE
Add composer configuration tests

### DIFF
--- a/tests/Unit/ComposerJsonTest.php
+++ b/tests/Unit/ComposerJsonTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class ComposerJsonTest extends TestCase
+{
+    /**
+     * Ensure that composer.json is valid JSON and contains essential keys.
+     */
+    public function test_composer_json_structure()
+    {
+        $path = dirname(__DIR__, 2) . '/composer.json';
+        $this->assertFileExists($path);
+
+        $content = file_get_contents($path);
+        $this->assertNotFalse($content, 'Unable to read composer.json');
+
+        $data = json_decode($content, true);
+        $this->assertIsArray($data, 'composer.json did not decode to array');
+        $this->assertArrayHasKey('name', $data);
+        $this->assertSame('itinerary/planner', $data['name']);
+        $this->assertArrayHasKey('require', $data);
+        $this->assertArrayHasKey('php', $data['require']);
+        $this->assertArrayHasKey('laravel/framework', $data['require']);
+        $this->assertArrayHasKey('scripts', $data);
+        $this->assertArrayHasKey('test', $data['scripts']);
+    }
+
+    /**
+     * Ensure that the Composer binary is available and reports a version.
+     */
+    public function test_composer_version_command()
+    {
+        $output = shell_exec('composer --version');
+        $this->assertIsString($output);
+        $this->assertStringContainsString('Composer version', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ComposerJsonTest` to verify `composer.json` structure and `composer` binary availability

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c43136dd083299cc25dd8a3ad4b2c