### PR TITLE
Fix activity deletion and add UI feedback

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Activity;
+use Illuminate\Support\Facades\Auth;
 class ActivityController extends Controller
 {
     protected $fillable = ['title', 'note', 'scheduled_at', 'location', 'latitude', 'longitude', 'itinerary_id'];
@@ -90,8 +91,14 @@ class ActivityController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Activity $activity)
     {
-        //
+        if ($activity->itinerary->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $activity->delete();
+
+        return redirect()->back()->with('success', 'Activity deleted.');
     }
 }

--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -9,6 +9,7 @@
     class="mt-4 space-y-3 divide-y divide-gray-200 dark:divide-gray-700">
 @foreach ($sorted as $index => $activity)
     <li
+        x-data="{ openDelete: false }"
         class="pt-3 first:pt-0 grid grid-cols-[auto_1fr_auto] gap-3
                hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition"
         data-marker-id="marker-{{ $activity->id }}"
@@ -59,15 +60,25 @@
                 </a>
 
                 {{-- Delete --}}
-                <form method="POST" action="{{ route('activities.destroy', $activity->id) }}"
-                      onsubmit="return confirm('Delete this activity?')">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit"
-                            class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 text-xs font-medium">
-                        Delete
-                    </button>
-                </form>
+                <button @click="openDelete = true"
+                        class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 text-xs font-medium">
+                    Delete
+                </button>
+                <div x-show="openDelete" x-cloak x-transition.opacity.scale.80
+                     class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+                    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
+                        <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-4">Delete this activity?</h2>
+                        <div class="flex justify-end gap-3">
+                            <button @click="openDelete = false"
+                                    class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
+                            <form method="POST" action="{{ route('activities.destroy', $activity->id) }}">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </li>

--- a/resources/views/components/itinerary-card.blade.php
+++ b/resources/views/components/itinerary-card.blade.php
@@ -5,6 +5,7 @@
 <div x-data="{
         openActivityForm: false,
         openEditModal : false,
+        openDeleteModal: false,
         activity      : {}        // currently-edited activity
     }" class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 space-y-4">
     <!-- ── Title & Info ─────────────────────────────────────────────── -->
@@ -22,11 +23,22 @@
         <div class="mt-2 flex items-center gap-2 text-sm">
             <a href="{{ route('itineraries.edit', $itinerary->id) }}" class="text-primary hover:underline">Edit</a>
 
-            <form method="POST" action="{{ route('itineraries.destroy', $itinerary->id) }}" onsubmit="return confirm('Delete this itinerary?')">
-                @csrf
-                @method('DELETE')
-                <button type="submit" class="text-red-600 hover:underline">Delete</button>
-            </form>
+            <button @click="openDeleteModal = true" class="text-red-600 hover:underline">Delete</button>
+            <div x-show="openDeleteModal" x-cloak x-transition.opacity.scale.80
+                class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+                <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
+                    <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-4">Delete this itinerary?</h2>
+                    <div class="flex justify-end gap-3">
+                        <button @click="openDeleteModal = false"
+                            class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
+                        <form method="POST" action="{{ route('itineraries.destroy', $itinerary->id) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/resources/views/components/toast.blade.php
+++ b/resources/views/components/toast.blade.php
@@ -1,0 +1,7 @@
+<div x-data="{ show: true }"
+     x-init="setTimeout(() => show = false, 3000)"
+     x-show="show"
+     x-transition
+     {{ $attributes->class('fixed top-4 right-4 z-50 px-4 py-2 rounded shadow text-white') }}>
+    {{ $slot }}
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -43,6 +43,16 @@
         <main>
             {{ $slot }}
         </main>
+        @if (session('success'))
+            <x-toast class="bg-green-600">
+                {{ session('success') }}
+            </x-toast>
+        @endif
+        @if (session('error'))
+            <x-toast class="bg-red-600">
+                {{ session('error') }}
+            </x-toast>
+        @endif
     </div>
     @stack('scripts')
 


### PR DESCRIPTION
## Summary
- allow deleting activities via controller
- add toast component and wire it up in the layout
- confirm activity deletion with modal
- confirm itinerary deletion with modal

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c437cb5b48329a3857d2d55c01c81