### PR TITLE
Improve delete activity modal

### DIFF
--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -67,14 +67,20 @@
                 <div x-show="openDelete" x-cloak x-transition.opacity.scale.80
                      class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
                     <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
-                        <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-4">Delete this activity?</h2>
+                        <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">Confirm Delete</h2>
+                        <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
+                            Are you sure you want to delete <span class="font-semibold">{{ $activity->title }}</span>
+                            scheduled for {{ \Carbon\Carbon::parse($activity->scheduled_at)->format('M j, g:i A') }}@if($activity->location)
+                                at {{ $activity->location }}@endif?
+                            This action cannot be undone.
+                        </p>
                         <div class="flex justify-end gap-3">
                             <button @click="openDelete = false"
                                     class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
                             <form method="POST" action="{{ route('activities.destroy', $activity->id) }}">
                                 @csrf
                                 @method('DELETE')
-                                <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
+                                <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">Delete</button>
                             </form>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- enhance delete confirmation text for activities
- add hover state to delete button

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c46ef559883298a4d5ea5f17a42a9