### PR TITLE
Fix nested group member route

### DIFF
--- a/resources/views/group-member/form.blade.php
+++ b/resources/views/group-member/form.blade.php
@@ -1,5 +1,5 @@
 @props(['itinerary'])
-<form method="POST" action="{{ route('group-members.store') }}" class="space-y-2">
+<form method="POST" action="{{ route('itineraries.group-members.store', $itinerary->id) }}" class="space-y-2">
     @csrf
     <input type="hidden" name="itinerary_id" value="{{ $itinerary->id }}">
     <div>


### PR DESCRIPTION
## Summary
- point group member form to `itineraries.group-members.store`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c62cbe5388329a828d26ae6203280