### PR TITLE
Improve itinerary detail design

### DIFF
--- a/resources/views/components/itinerary-card.blade.php
+++ b/resources/views/components/itinerary-card.blade.php
@@ -6,6 +6,7 @@
         openActivityForm: false,
         openEditModal : false,
         openDeleteModal: false,
+        openMemberModal: false,
         activity      : {}        // currently-edited activity
     }" class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 space-y-4">
     <!-- ── Title & Info ─────────────────────────────────────────────── -->
@@ -22,9 +23,28 @@
 
     @if($itinerary->groupMembers->count())
         <x-group-member-list :members="$itinerary->groupMembers" />
+    @else
+        <p class="text-sm text-gray-400 italic">No group members yet.</p>
     @endif
 
-    @include('group-member.form', ['itinerary' => $itinerary])
+    <button @click="openMemberModal = true"
+        class="mt-2 px-3 py-1 bg-primary hover:bg-primary-light text-white rounded text-sm">
+        + Add Member
+    </button>
+
+    <div x-show="openMemberModal" x-cloak x-transition.opacity.scale.80
+        class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-md">
+            <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-4">Add Member</h2>
+            @include('group-member.form', ['itinerary' => $itinerary])
+            <div class="text-right mt-2">
+                <button @click="openMemberModal = false"
+                    class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">
+                    Close
+                </button>
+            </div>
+        </div>
+    </div>
 
         <div class="mt-2 flex items-center gap-2 text-sm">
             <a href="{{ route('itineraries.edit', $itinerary->id) }}" class="text-primary hover:underline">Edit</a>
@@ -62,13 +82,13 @@
 
     <!-- ── Add-Activity Button ──────────────────────────────────────── -->
     <div class="flex gap-2">
-        <button @click="
-        activity = {};           /* blank object for new record */
-        openActivityForm = true
-    " class="px-3 py-1 bg-primary hover:bg-primary-dark text-white text-sm rounded">
+        <x-primary-button type="button" class="text-xs" @click="activity = {}; openActivityForm = true">
             + Add Activity
-        </button>
-        <a href="{{ route('itineraries.budgets.index', $itinerary->id) }}" class="px-3 py-1 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded">Budget</a>
+        </x-primary-button>
+        <a href="{{ route('itineraries.budgets.index', $itinerary->id) }}"
+            class="inline-flex items-center px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded-md">
+            Budget
+        </a>
     </div>
 
     <!-- ── Add-Activity Modal ───────────────────────────────────────── -->

--- a/resources/views/group-member/form.blade.php
+++ b/resources/views/group-member/form.blade.php
@@ -11,6 +11,6 @@
                class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
     </div>
     <div class="text-right">
-        <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Add</button>
+        <x-primary-button type="submit" class="text-xs">Add</x-primary-button>
     </div>
 </form>


### PR DESCRIPTION
## Summary
- add group member modal to itinerary card
- use primary button component in member form
- restyle activity button with Tailwind component

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c6687719c83298864b556a54ca388