### PR TITLE
Add itinerary details view and navigation links

### DIFF
--- a/resources/views/components/itinerary-card.blade.php
+++ b/resources/views/components/itinerary-card.blade.php
@@ -89,6 +89,10 @@
             class="inline-flex items-center px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded-md">
             Budget
         </a>
+        <a href="{{ route('itineraries.show', $itinerary->id) }}"
+            class="inline-flex items-center px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-white text-xs rounded-md">
+            Details
+        </a>
     </div>
 
     <!-- ── Add-Activity Modal ───────────────────────────────────────── -->

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -5,7 +5,44 @@
         </h2>
     </x-slot>
 
-    <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8">
+    <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
         <x-itinerary-card :itinerary="$itinerary" />
+
+        <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6">
+            <h3 class="text-lg font-semibold text-gray-800 dark:text-white mb-4">Budget Overview</h3>
+            @if($itinerary->budgetEntries->count())
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 mb-4">
+                    <thead>
+                        <tr class="text-left">
+                            <th class="py-2">Description</th>
+                            <th class="py-2">Amount</th>
+                            <th class="py-2">Date</th>
+                            <th class="py-2">Category</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach($itinerary->budgetEntries as $entry)
+                            <tr>
+                                <td class="py-2">{{ $entry->description }}</td>
+                                <td class="py-2">${{ number_format($entry->amount, 2) }}</td>
+                                <td class="py-2">{{ $entry->entry_date }}</td>
+                                <td class="py-2">{{ $entry->category }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+                <x-budget-chart :entries="$itinerary->budgetEntries" />
+                <p class="text-sm text-gray-600 dark:text-gray-300 mt-4">
+                    Total: ${{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}
+                </p>
+                @if($averageBudget)
+                    <p class="text-sm text-gray-600 dark:text-gray-300">
+                        Average budget for itineraries with activities in {{ $primaryLocation }}: ${{ number_format($averageBudget, 2) }}
+                    </p>
+                @endif
+            @else
+                <p class="text-gray-500 dark:text-gray-400">No budget entries yet.</p>
+            @endif
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,9 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('itineraries.index')" :active="request()->routeIs('itineraries.*')">
+                        {{ __('Itineraries') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -74,6 +77,9 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('itineraries.index')" :active="request()->routeIs('itineraries.*')">
+                {{ __('Itineraries') }}
             </x-responsive-nav-link>
             <div class="px-4 pt-2">
                 <x-theme-toggle />


### PR DESCRIPTION
## Summary
- add link to itinerary details from dashboard cards
- show budget info & comparison on itinerary detail page
- expose itinerary details in header navigation

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c6839e8d08329b11da4f104c7d39e