### PR TITLE
Add edit and delete options for group members

### DIFF
--- a/resources/views/components/group-member-list.blade.php
+++ b/resources/views/components/group-member-list.blade.php
@@ -1,18 +1,52 @@
 @props(['members'])
 <ul class="mt-4 space-y-2">
     @foreach($members as $member)
-        <li class="flex justify-between items-center bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
+        <li x-data="{ openEdit: false, openDelete: false }" class="flex justify-between items-center bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
             <div>
                 <p class="text-sm font-medium text-gray-800 dark:text-white">{{ $member->name }}</p>
                 @if($member->notes)
                     <p class="text-xs text-gray-500 dark:text-gray-300">{{ $member->notes }}</p>
                 @endif
             </div>
-            <form method="POST" action="{{ route('group-members.destroy', $member->id) }}">
-                @csrf
-                @method('DELETE')
-                <button class="text-red-600 text-xs">Remove</button>
-            </form>
+            <div class="flex items-center gap-2">
+                <a href="#" @click.prevent="openEdit = true" class="text-primary text-xs">Edit</a>
+                <button @click="openDelete = true" class="text-red-600 text-xs">Delete</button>
+            </div>
+
+            <div x-show="openEdit" x-cloak x-transition.opacity.scale.80 class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+                <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-md">
+                    <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-4">Edit Member</h2>
+                    <form method="POST" action="{{ route('group-members.update', $member->id) }}" class="space-y-2">
+                        @csrf
+                        @method('PUT')
+                        <input type="text" name="name" value="{{ $member->name }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                        <input type="text" name="notes" value="{{ $member->notes }}" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                        <div class="text-right">
+                            <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Update</button>
+                        </div>
+                    </form>
+                    <div class="text-right mt-2">
+                        <button @click="openEdit = false" class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Close</button>
+                    </div>
+                </div>
+            </div>
+
+            <div x-show="openDelete" x-cloak x-transition.opacity.scale.80 class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+                <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
+                    <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">Confirm Delete</h2>
+                    <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
+                        Are you sure you want to delete <span class="font-semibold">{{ $member->name }}</span>? This action cannot be undone.
+                    </p>
+                    <div class="flex justify-end gap-3">
+                        <button @click="openDelete = false" class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
+                        <form method="POST" action="{{ route('group-members.destroy', $member->id) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">Delete</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
         </li>
     @endforeach
 </ul>


### PR DESCRIPTION
## Summary
- add edit and delete modals to group-member list

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c6972db7883298d8e7cc05b6eb9e9