### PR TITLE
Move dashboard actions and add sample data

### DIFF
--- a/database/migrations/2025_08_01_073700_seed_sample_itineraries.php
+++ b/database/migrations/2025_08_01_073700_seed_sample_itineraries.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Carbon;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // ensure a sample user exists
+        DB::table('users')->insert([
+            'id' => 1,
+            'name' => 'Sample User',
+            'email' => 'sample@example.com',
+            'password' => bcrypt('password'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('itineraries')->insert([
+            [
+                'user_id' => 1,
+                'title' => 'Weekend Getaway',
+                'description' => 'Short trip to the mountains',
+                'start_date' => Carbon::today()->addDays(7),
+                'end_date' => Carbon::today()->addDays(9),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'user_id' => 1,
+                'title' => 'Business Trip',
+                'description' => 'Conference in New York',
+                'start_date' => Carbon::today()->addDays(14),
+                'end_date' => Carbon::today()->addDays(17),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('itineraries')->whereIn('title', ['Weekend Getaway', 'Business Trip'])->delete();
+        DB::table('users')->where('email', 'sample@example.com')->delete();
+    }
+};

--- a/resources/views/components/budget-category-chart.blade.php
+++ b/resources/views/components/budget-category-chart.blade.php
@@ -1,0 +1,24 @@
+@props(['entries'])
+<div class="mt-6">
+    <canvas id="budget-category-chart" height="200"></canvas>
+</div>
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const ctx = document.getElementById('budget-category-chart');
+        const data = @json($entries->groupBy('category')->map(fn($items) => $items->sum('amount')));
+        new Chart(ctx, {
+            type: 'doughnut',
+            data: {
+                labels: Object.keys(data),
+                datasets: [{
+                    data: Object.values(data),
+                    backgroundColor: ['#60a5fa', '#34d399', '#fbbf24', '#f87171', '#a78bfa'],
+                }]
+            }
+        });
+    });
+</script>
+@endpush

--- a/resources/views/components/itinerary-card.blade.php
+++ b/resources/views/components/itinerary-card.blade.php
@@ -1,5 +1,5 @@
 {{-- Itinerary Card --}}
-@props(['itinerary'])
+@props(['itinerary', 'showActions' => true])
 
 {{-- One Alpine scope controls everything inside --}}
 <div x-data="{
@@ -46,38 +46,40 @@
         </div>
     </div>
 
-        <div class="mt-2 flex items-center gap-2 text-sm">
-            <a href="{{ route('itineraries.edit', $itinerary->id) }}"
-               class="inline-flex items-center px-2 py-1 bg-primary hover:bg-primary-dark text-white rounded text-xs">
-                Edit
-            </a>
+        @if($showActions)
+            <div class="mt-2 flex items-center gap-2 text-sm">
+                <a href="{{ route('itineraries.edit', $itinerary->id) }}"
+                   class="inline-flex items-center px-2 py-1 bg-primary hover:bg-primary-dark text-white rounded text-xs">
+                    Edit
+                </a>
 
-            <button @click="openDeleteModal = true"
-                class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs">
-                Delete
-            </button>
-            <div x-show="openDeleteModal" x-cloak x-transition.opacity.scale.80
-                class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-                <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
-                    <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">Confirm Delete</h2>
-                    <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
-                        Are you sure you want to delete <span class="font-semibold">{{ $itinerary->title }}</span>
-                        scheduled from {{ $itinerary->start_date }} to {{ $itinerary->end_date }}?
-                        This action cannot be undone.
-                    </p>
-                    <div class="flex justify-end gap-3">
-                        <button @click="openDeleteModal = false"
-                            class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
-                        <form method="POST" action="{{ route('itineraries.destroy', $itinerary->id) }}">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">Delete</button>
-                        </form>
+                <button @click="openDeleteModal = true"
+                    class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs">
+                    Delete
+                </button>
+                <div x-show="openDeleteModal" x-cloak x-transition.opacity.scale.80
+                    class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+                    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
+                        <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">Confirm Delete</h2>
+                        <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
+                            Are you sure you want to delete <span class="font-semibold">{{ $itinerary->title }}</span>
+                            scheduled from {{ $itinerary->start_date }} to {{ $itinerary->end_date }}?
+                            This action cannot be undone.
+                        </p>
+                        <div class="flex justify-end gap-3">
+                            <button @click="openDeleteModal = false"
+                                class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
+                            <form method="POST" action="{{ route('itineraries.destroy', $itinerary->id) }}">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">Delete</button>
+                            </form>
+                        </div>
                     </div>
                 </div>
             </div>
+        @endif
         </div>
-    </div>
 
     <!-- ── Activities List ──────────────────────────────────────────── -->
     @if($itinerary->activities->count())

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -88,7 +88,7 @@
 
     <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
         @foreach ($itineraries as $itinerary)
-            <x-itinerary-card :itinerary="$itinerary" />
+            <x-itinerary-card :itinerary="$itinerary" :show-actions="false" />
 
         @endforeach
         {{ $itineraries->links() }}

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -32,12 +32,21 @@
                     </tbody>
                 </table>
                 <x-budget-chart :entries="$itinerary->budgetEntries" />
+                <x-budget-category-chart :entries="$itinerary->budgetEntries" />
+                @php
+                    $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
+                    $topCategory = $categoryTotals->sortDesc()->keys()->first();
+                @endphp
+                <p class="text-sm text-gray-600 dark:text-gray-300 mt-4">
+                    Top spending category: {{ $topCategory }} (${{ number_format($categoryTotals[$topCategory], 2) }})
+                </p>
                 <p class="text-sm text-gray-600 dark:text-gray-300 mt-4">
                     Total: ${{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}
                 </p>
                 @if($averageBudget)
                     <p class="text-sm text-gray-600 dark:text-gray-300">
                         Average budget for itineraries with activities in {{ $primaryLocation }}: ${{ number_format($averageBudget, 2) }}
+                        ({{ round(($itinerary->budgetEntries->sum('amount') - $averageBudget) / $averageBudget * 100, 1) }}% {{ $itinerary->budgetEntries->sum('amount') >= $averageBudget ? 'above' : 'below' }} average)
                     </p>
                 @endif
             @else


### PR DESCRIPTION
## Summary
- add new budget category chart
- move Edit/Delete buttons from dashboard to itinerary details
- show insight into budget categories and comparisons
- seed sample itineraries via migration

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c6e05e48083299729fc51bf31f8c5