### PR TITLE
Enable image uploads and highlight required fields

### DIFF
--- a/app/Http/Controllers/GroupMemberController.php
+++ b/app/Http/Controllers/GroupMemberController.php
@@ -16,7 +16,12 @@ class GroupMemberController extends Controller
             'itinerary_id' => 'required|exists:itineraries,id',
             'name' => 'required|string|max:255',
             'notes' => 'nullable|string',
+            'photo' => 'nullable|image|max:2048',
         ]);
+
+        if ($request->hasFile('photo')) {
+            $validated['photo_path'] = $request->file('photo')->store('group_members', 'public');
+        }
 
         GroupMember::create($validated);
 
@@ -32,7 +37,12 @@ class GroupMemberController extends Controller
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'notes' => 'nullable|string',
+            'photo' => 'nullable|image|max:2048',
         ]);
+
+        if ($request->hasFile('photo')) {
+            $validated['photo_path'] = $request->file('photo')->store('group_members', 'public');
+        }
 
         $groupMember->update($validated);
 

--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -56,15 +56,22 @@ class ItineraryController extends Controller
             'description' => 'nullable|string',
             'start_date' => 'required|date|after_or_equal:today',
             'end_date' => 'required|date|after_or_equal:start_date',
+            'photo' => 'nullable|image|max:2048',
         ]);
 
-        Itinerary::create([
+        $data = [
             'user_id' => Auth::id(),
             'title' => $request->title,
             'description' => $request->description,
             'start_date' => $request->start_date,
             'end_date' => $request->end_date,
-        ]);
+        ];
+
+        if ($request->hasFile('photo')) {
+            $data['photo_path'] = $request->file('photo')->store('itineraries', 'public');
+        }
+
+        Itinerary::create($data);
 
         return redirect()->route('dashboard')->with('success', 'Itinerary created.');
     }
@@ -115,7 +122,12 @@ class ItineraryController extends Controller
             'description' => 'nullable|string',
             'start_date' => 'required|date|after_or_equal:today',
             'end_date' => 'required|date|after_or_equal:start_date',
+            'photo' => 'nullable|image|max:2048',
         ]);
+
+        if ($request->hasFile('photo')) {
+            $validated['photo_path'] = $request->file('photo')->store('itineraries', 'public');
+        }
 
         $itinerary->update($validated);
 

--- a/app/Models/GroupMember.php
+++ b/app/Models/GroupMember.php
@@ -9,6 +9,7 @@ class GroupMember extends Model
         'itinerary_id',
         'name',
         'notes',
+        'photo_path',
     ];
 
     public function itinerary()

--- a/app/Models/Itinerary.php
+++ b/app/Models/Itinerary.php
@@ -12,6 +12,7 @@ class Itinerary extends Model
         'description',
         'start_date',
         'end_date',
+        'photo_path',
     ];
 
     public function activities()

--- a/database/migrations/2025_08_02_010000_add_photo_path_to_itineraries_and_group_members.php
+++ b/database/migrations/2025_08_02_010000_add_photo_path_to_itineraries_and_group_members.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('itineraries', function (Blueprint $table) {
+            $table->string('photo_path')->nullable()->after('end_date');
+        });
+
+        Schema::table('group_members', function (Blueprint $table) {
+            $table->string('photo_path')->nullable()->after('notes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('group_members', function (Blueprint $table) {
+            $table->dropColumn('photo_path');
+        });
+
+        Schema::table('itineraries', function (Blueprint $table) {
+            $table->dropColumn('photo_path');
+        });
+    }
+};

--- a/resources/views/activity/activity-form.blade.php
+++ b/resources/views/activity/activity-form.blade.php
@@ -40,7 +40,7 @@
 
             <!-- Title -->
             <div class="flex flex-col space-y-1">
-                <label class="font-medium text-gray-700 dark:text-gray-300">Title</label>
+                <label class="font-medium text-gray-700 dark:text-gray-300">Title <span class="text-red-500">*</span></label>
                 <input type="text" name="title" required
                        x-model="activity.title"
                        class="px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white
@@ -168,7 +168,7 @@
 
             <!-- Date & time -->
             <div class="flex flex-col space-y-1">
-                <label class="font-medium text-gray-700 dark:text-gray-300">Date &amp; time</label>
+                <label class="font-medium text-gray-700 dark:text-gray-300">Date &amp; time <span class="text-red-500">*</span></label>
                 <input type="datetime-local" name="scheduled_at" required
                        x-model="activity.scheduled_at"
                        class="px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white
@@ -200,3 +200,4 @@
         </div>
     </form>
 </div>
+

--- a/resources/views/booking/booking-form.blade.php
+++ b/resources/views/booking/booking-form.blade.php
@@ -17,7 +17,7 @@
         <input type="hidden" name="itinerary_id" :value="booking.itinerary_id ?? '{{ $itinerary->id }}'">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div class="flex flex-col space-y-1">
-                <label class="font-medium text-gray-700 dark:text-gray-300">Place</label>
+                <label class="font-medium text-gray-700 dark:text-gray-300">Place <span class="text-red-500">*</span></label>
                 <input type="text" name="place" x-model="booking.place" required class="px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-inset ring-gray-300 focus:ring-primary focus:ring-2 outline-none">
             </div>
             <div class="flex flex-col space-y-1">
@@ -25,11 +25,11 @@
                 <input type="text" name="location" x-model="booking.location" class="px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-inset ring-gray-300 focus:ring-primary focus:ring-2 outline-none">
             </div>
             <div class="flex flex-col space-y-1">
-                <label class="font-medium text-gray-700 dark:text-gray-300">Check-in</label>
+                <label class="font-medium text-gray-700 dark:text-gray-300">Check-in <span class="text-red-500">*</span></label>
                 <input type="date" name="check_in" x-model="booking.check_in" required class="px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-inset ring-gray-300 focus:ring-primary focus:ring-2 outline-none">
             </div>
             <div class="flex flex-col space-y-1">
-                <label class="font-medium text-gray-700 dark:text-gray-300">Check-out</label>
+                <label class="font-medium text-gray-700 dark:text-gray-300">Check-out <span class="text-red-500">*</span></label>
                 <input type="date" name="check_out" x-model="booking.check_out" required class="px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-inset ring-gray-300 focus:ring-primary focus:ring-2 outline-none">
             </div>
             <div class="sm:col-span-2 space-y-2">
@@ -92,3 +92,4 @@
         </div>
     </form>
 </div>
+

--- a/resources/views/budgets/edit.blade.php
+++ b/resources/views/budgets/edit.blade.php
@@ -9,10 +9,22 @@
         <form method="POST" action="{{ route('budgets.update', $budgetEntry->id) }}" class="space-y-2">
             @csrf
             @method('PUT')
-            <input type="text" name="description" value="{{ old('description', $budgetEntry->description) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            <input type="number" step="0.01" name="amount" value="{{ old('amount', $budgetEntry->amount) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            <input type="date" name="entry_date" value="{{ old('entry_date', $budgetEntry->entry_date) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            <input type="text" name="category" value="{{ old('category', $budgetEntry->category) }}" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            <div>
+                <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Description <span class="text-red-500">*</span></label>
+                <input type="text" id="description" name="description" value="{{ old('description', $budgetEntry->description) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
+            <div>
+                <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Amount <span class="text-red-500">*</span></label>
+                <input type="number" step="0.01" id="amount" name="amount" value="{{ old('amount', $budgetEntry->amount) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
+            <div>
+                <label for="entry_date" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Date <span class="text-red-500">*</span></label>
+                <input type="date" id="entry_date" name="entry_date" value="{{ old('entry_date', $budgetEntry->entry_date) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
+            <div>
+                <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
+                <input type="text" id="category" name="category" value="{{ old('category', $budgetEntry->category) }}" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
             <div class="text-right">
                 <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Update</button>
             </div>

--- a/resources/views/budgets/index.blade.php
+++ b/resources/views/budgets/index.blade.php
@@ -9,10 +9,22 @@
         <form method="POST" action="{{ route('itineraries.budgets.store', $itinerary->id) }}" class="space-y-2">
             @csrf
             <input type="hidden" name="itinerary_id" value="{{ $itinerary->id }}">
-            <input type="text" name="description" placeholder="Description" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            <input type="number" step="0.01" name="amount" placeholder="Amount" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            <input type="date" name="entry_date" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            <input type="text" name="category" placeholder="Category" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            <div>
+                <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Description <span class="text-red-500">*</span></label>
+                <input type="text" id="description" name="description" placeholder="Description" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
+            <div>
+                <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Amount <span class="text-red-500">*</span></label>
+                <input type="number" step="0.01" id="amount" name="amount" placeholder="Amount" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
+            <div>
+                <label for="entry_date" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Date <span class="text-red-500">*</span></label>
+                <input type="date" id="entry_date" name="entry_date" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
+            <div>
+                <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
+                <input type="text" id="category" name="category" placeholder="Category" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
             <div class="text-right">
                 <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Add</button>
             </div>

--- a/resources/views/components/group-member-list.blade.php
+++ b/resources/views/components/group-member-list.blade.php
@@ -22,11 +22,20 @@
             <div x-show="openEdit" x-cloak x-transition.opacity.scale.80 class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
                 <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-md">
                     <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-4">Edit Member</h2>
-                    <form method="POST" action="{{ route('group-members.update', $member->id) }}" class="space-y-2">
+                    <form method="POST" action="{{ route('group-members.update', $member->id) }}" class="space-y-2" enctype="multipart/form-data">
                         @csrf
                         @method('PUT')
-                        <input type="text" name="name" value="{{ $member->name }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-                        <input type="text" name="notes" value="{{ $member->notes }}" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                        <div>
+                            <label for="member-name-{{ $member->id }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Name <span class="text-red-500">*</span></label>
+                            <input type="text" id="member-name-{{ $member->id }}" name="name" value="{{ $member->name }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                        </div>
+                        <div>
+                            <input type="text" name="notes" value="{{ $member->notes }}" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                        </div>
+                        <div>
+                            <label for="member-photo-{{ $member->id }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Photo</label>
+                            <input type="file" id="member-photo-{{ $member->id }}" name="photo" class="w-full text-gray-900 dark:text-white">
+                        </div>
                         <div class="text-right">
                             <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Update</button>
                         </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -15,12 +15,12 @@
                     @click.away="openForm = false">
                     <h3 class="text-lg font-semibold mb-4 text-gray-800 dark:text-white">New Itinerary</h3>
 
-                    <form method="POST" action="{{ route('itineraries.store') }}">
+                    <form method="POST" action="{{ route('itineraries.store') }}" enctype="multipart/form-data">
                         @csrf
 
                         <div class="mb-4">
                             <label for="title"
-                                class="block text-sm font-medium text-gray-700 dark:text-gray-200">Title</label>
+                                class="block text-sm font-medium text-gray-700 dark:text-gray-200">Title <span class="text-red-500">*</span></label>
                             <input type="text" name="title" id="title" required
                                 class="mt-1 block w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white" />
                         </div>
@@ -34,16 +34,22 @@
 
                         <div class="mb-4">
                             <label for="start_date"
-                                class="block text-sm font-medium text-gray-700 dark:text-gray-200">Start Date</label>
+                                class="block text-sm font-medium text-gray-700 dark:text-gray-200">Start Date <span class="text-red-500">*</span></label>
                             <input type="date" name="start_date" id="start_date" required
                                 class="mt-1 block w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white" />
                         </div>
 
                         <div class="mb-4">
                             <label for="end_date" class="block text-sm font-medium text-gray-700 dark:text-gray-200">End
-                                Date</label>
+                                Date <span class="text-red-500">*</span></label>
                             <input type="date" name="end_date" id="end_date" required
                                 class="mt-1 block w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white" />
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="photo" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Photo</label>
+                            <input type="file" name="photo" id="photo"
+                                class="mt-1 block w-full text-gray-900 dark:text-white" />
                         </div>
 
                         <div class="flex justify-end gap-2">

--- a/resources/views/group-member/form.blade.php
+++ b/resources/views/group-member/form.blade.php
@@ -1,14 +1,19 @@
 @props(['itinerary'])
-<form method="POST" action="{{ route('itineraries.group-members.store', $itinerary->id) }}" class="space-y-2">
+<form method="POST" action="{{ route('itineraries.group-members.store', $itinerary->id) }}" class="space-y-2" enctype="multipart/form-data">
     @csrf
     <input type="hidden" name="itinerary_id" value="{{ $itinerary->id }}">
     <div>
-        <input type="text" name="name" placeholder="Name" required
+        <label for="name" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Name <span class="text-red-500">*</span></label>
+        <input type="text" id="name" name="name" placeholder="Name" required
                class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
     </div>
     <div>
         <input type="text" name="notes" placeholder="Notes"
                class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+    </div>
+    <div>
+        <label for="photo" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Photo</label>
+        <input type="file" id="photo" name="photo" class="w-full text-gray-900 dark:text-white">
     </div>
     <div class="text-right">
         <x-primary-button type="submit" class="text-xs">Add</x-primary-button>

--- a/resources/views/itineraries/create.blade.php
+++ b/resources/views/itineraries/create.blade.php
@@ -12,11 +12,11 @@
             <span x-show="open">Hide Form</span>
         </button>
 
-        <form method="POST" action="{{ route('itineraries.store') }}" x-show="open" x-transition>
+        <form method="POST" action="{{ route('itineraries.store') }}" x-show="open" x-transition enctype="multipart/form-data">
             @csrf
 
             <div class="mb-4">
-                <label for="title" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Title</label>
+                <label for="title" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Title <span class="text-red-500">*</span></label>
                 <input type="text" name="title" id="title" required
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
             </div>
@@ -28,15 +28,21 @@
             </div>
 
             <div class="mb-4">
-                <label for="start_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Start Date</label>
+                <label for="start_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Start Date <span class="text-red-500">*</span></label>
                 <input type="date" name="start_date" id="start_date" required
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
             </div>
 
             <div class="mb-4">
-                <label for="end_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">End Date</label>
-                <input type="date" name="end_date" id="end_date" required
+                <label for="end_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">End Date <span class="text-red-500">*</span></label>
+            <input type="date" name="end_date" id="end_date" required
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+            </div>
+
+            <div class="mb-4">
+                <label for="photo" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Photo</label>
+                <input type="file" name="photo" id="photo"
+                    class="mt-1 block w-full text-gray-900 dark:text-white" />
             </div>
 
             <button type="submit"

--- a/resources/views/itineraries/edit.blade.php
+++ b/resources/views/itineraries/edit.blade.php
@@ -6,12 +6,12 @@
     </x-slot>
 
     <div class="py-10 max-w-2xl mx-auto sm:px-6 lg:px-8">
-        <form method="POST" action="{{ route('itineraries.update', $itinerary->id) }}">
+        <form method="POST" action="{{ route('itineraries.update', $itinerary->id) }}" enctype="multipart/form-data">
             @csrf
             @method('PUT')
 
             <div class="mb-4">
-                <label for="title" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Title</label>
+                <label for="title" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Title <span class="text-red-500">*</span></label>
                 <input type="text" name="title" id="title" required value="{{ old('title', $itinerary->title) }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
             </div>
@@ -22,15 +22,21 @@
             </div>
 
             <div class="mb-4">
-                <label for="start_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Start Date</label>
+                <label for="start_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Start Date <span class="text-red-500">*</span></label>
                 <input type="date" name="start_date" id="start_date" required value="{{ old('start_date', $itinerary->start_date) }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
             </div>
 
             <div class="mb-4">
-                <label for="end_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">End Date</label>
-                <input type="date" name="end_date" id="end_date" required value="{{ old('end_date', $itinerary->end_date) }}"
+                <label for="end_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">End Date <span class="text-red-500">*</span></label>
+            <input type="date" name="end_date" id="end_date" required value="{{ old('end_date', $itinerary->end_date) }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+            </div>
+
+            <div class="mb-4">
+                <label for="photo" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Photo</label>
+                <input type="file" name="photo" id="photo"
+                    class="mt-1 block w-full text-gray-900 dark:text-white" />
             </div>
 
             <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded shadow">


### PR DESCRIPTION
## Summary
- allow itineraries and group members to include optional photos
- show asterisk on required fields across itinerary, booking, activity, and budget forms

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_688dc19cf76083299dee335f1eac07cd