### PR TITLE
Use segmented colors for budget bar chart

### DIFF
--- a/resources/views/components/budget-chart.blade.php
+++ b/resources/views/components/budget-chart.blade.php
@@ -12,6 +12,9 @@
             'date' => $e->entry_date->format('Y-m-d'),
             'amount' => (float) $e->amount,
         ]));
+
+        const colors = ['#60a5fa', '#34d399', '#fbbf24', '#f87171', '#a78bfa'];
+
         new Chart(ctx, {
             type: 'bar',
             data: {
@@ -19,7 +22,7 @@
                 datasets: [{
                     label: 'Amount',
                     data: data.map(d => d.amount),
-                    backgroundColor: '#60a5fa',
+                    backgroundColor: data.map((_, i) => colors[i % colors.length]),
                 }]
             },
             options: {


### PR DESCRIPTION
## Summary
- cycle through five colors so each bar chart column has its own segment color

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688dc182841083298236533b26c93cf0