### PR TITLE
Add PHP currency and budget statistics

### DIFF
--- a/resources/views/budgets/index.blade.php
+++ b/resources/views/budgets/index.blade.php
@@ -57,7 +57,7 @@
                     @foreach($itinerary->budgetEntries as $entry)
                         <tr>
                             <td class="py-2">{{ $entry->description }}</td>
-                            <td class="py-2">${{ number_format($entry->amount, 2) }}</td>
+                            <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
                             <td class="py-2">{{ $entry->entry_date }}</td>
                             <td class="py-2">{{ $entry->category }}</td>
                             <td class="py-2 text-right">
@@ -75,7 +75,15 @@
                 </tbody>
             </table>
 
-            <p class="text-right font-semibold mt-2">Total Spent: ${{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}</p>
+            @php
+                $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
+            @endphp
+            <p class="text-right font-semibold mt-2">Total Spent: PHP{{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}</p>
+            <ul class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                @foreach($categoryTotals as $category => $total)
+                    <li>{{ $category }}: PHP{{ number_format($total, 2) }}</li>
+                @endforeach
+            </ul>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <x-budget-chart :entries="$itinerary->budgetEntries" />

--- a/resources/views/budgets/show.blade.php
+++ b/resources/views/budgets/show.blade.php
@@ -7,7 +7,7 @@
 
     <div class="py-6 max-w-xl mx-auto space-y-4">
         <p><strong>Description:</strong> {{ $budgetEntry->description }}</p>
-        <p><strong>Amount:</strong> ${{ number_format($budgetEntry->amount,2) }}</p>
+        <p><strong>Amount:</strong> PHP{{ number_format($budgetEntry->amount,2) }}</p>
         <p><strong>Date:</strong> {{ $budgetEntry->entry_date }}</p>
         <p><strong>Category:</strong> {{ $budgetEntry->category }}</p>
     </div>

--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -38,7 +38,7 @@
                 </p>
             @endif
             @if ($activity->budget)
-                <p class="text-xs text-gray-500 dark:text-gray-400">Budget: ${{ number_format($activity->budget, 2) }}</p>
+                <p class="text-xs text-gray-500 dark:text-gray-400">Budget: PHP{{ number_format($activity->budget, 2) }}</p>
             @endif
             @if ($activity->attire_color || $activity->attire_note)
                 <p class="text-xs text-gray-500 dark:text-gray-400">

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -24,7 +24,7 @@
                         @foreach($itinerary->budgetEntries as $entry)
                             <tr>
                                 <td class="py-2">{{ $entry->description }}</td>
-                                <td class="py-2">${{ number_format($entry->amount, 2) }}</td>
+                                <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
                                 <td class="py-2">{{ $entry->entry_date }}</td>
                                 <td class="py-2">{{ $entry->category }}</td>
                             </tr>
@@ -37,15 +37,20 @@
                     $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
                     $topCategory = $categoryTotals->sortDesc()->keys()->first();
                 @endphp
+                <ul class="text-sm text-gray-600 dark:text-gray-300 mt-4 space-y-1">
+                    @foreach($categoryTotals as $category => $total)
+                        <li>{{ $category }}: PHP{{ number_format($total, 2) }}</li>
+                    @endforeach
+                </ul>
                 <p class="text-sm text-gray-600 dark:text-gray-300 mt-4">
-                    Top spending category: {{ $topCategory }} (${{ number_format($categoryTotals[$topCategory], 2) }})
+                    Top spending category: {{ $topCategory }} (PHP{{ number_format($categoryTotals[$topCategory], 2) }})
                 </p>
                 <p class="text-sm text-gray-600 dark:text-gray-300 mt-4">
-                    Total: ${{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}
+                    Total: PHP{{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}
                 </p>
                 @if($averageBudget)
                     <p class="text-sm text-gray-600 dark:text-gray-300">
-                        Average budget for itineraries with activities in {{ $primaryLocation }}: ${{ number_format($averageBudget, 2) }}
+                        Average budget for itineraries with activities in {{ $primaryLocation }}: PHP{{ number_format($averageBudget, 2) }}
                         ({{ round(($itinerary->budgetEntries->sum('amount') - $averageBudget) / $averageBudget * 100, 1) }}% {{ $itinerary->budgetEntries->sum('amount') >= $averageBudget ? 'above' : 'below' }} average)
                     </p>
                 @endif


### PR DESCRIPTION
## Summary
- Show PHP currency in budget and activity views
- List category totals in budget overview

## Testing
- `composer test` *(fails: file_get_contents(/workspace/itinerary-planner/.env): Failed to open stream: No such file)*

------
https://chatgpt.com/codex/tasks/task_e_688dc7f794ac832992095e937bfcbf3b