### PR TITLE
Handle missing itinerary on budget entry

### DIFF
--- a/app/Http/Controllers/BudgetEntryController.php
+++ b/app/Http/Controllers/BudgetEntryController.php
@@ -64,7 +64,7 @@ class BudgetEntryController extends Controller
      */
     public function show(BudgetEntry $budgetEntry)
     {
-        if ($budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
             abort(403);
         }
 
@@ -76,7 +76,7 @@ class BudgetEntryController extends Controller
      */
     public function edit(BudgetEntry $budgetEntry)
     {
-        if ($budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
             abort(403);
         }
 
@@ -88,7 +88,7 @@ class BudgetEntryController extends Controller
      */
     public function update(Request $request, BudgetEntry $budgetEntry)
     {
-        if ($budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
             abort(403);
         }
 
@@ -109,7 +109,7 @@ class BudgetEntryController extends Controller
      */
     public function destroy(BudgetEntry $budgetEntry)
     {
-        if ($budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
             abort(403);
         }
 


### PR DESCRIPTION
## Summary
- avoid accessing null itinerary when viewing or updating a budget entry

## Testing
- `php artisan test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688dce056d2483298c4b8e81f3d958b4