### PR TITLE
Fix budget editing authorization

### DIFF
--- a/app/Http/Controllers/BudgetEntryController.php
+++ b/app/Http/Controllers/BudgetEntryController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\BudgetEntry;
 use App\Models\Itinerary;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class BudgetEntryController extends Controller
@@ -48,10 +48,10 @@ class BudgetEntryController extends Controller
 
         $validated = $request->validate([
             'itinerary_id' => 'required|exists:itineraries,id',
-            'description'  => 'required|string|max:255',
-            'amount'       => 'required|numeric',
-            'entry_date'   => 'required|date',
-            'category'     => 'nullable|string|max:255',
+            'description' => 'required|string|max:255',
+            'amount' => 'required|numeric',
+            'entry_date' => 'required|date',
+            'category' => 'nullable|string|max:255',
         ]);
 
         BudgetEntry::create($validated);
@@ -64,7 +64,7 @@ class BudgetEntryController extends Controller
      */
     public function show(BudgetEntry $budgetEntry)
     {
-        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
             abort(403);
         }
 
@@ -76,7 +76,7 @@ class BudgetEntryController extends Controller
      */
     public function edit(BudgetEntry $budgetEntry)
     {
-        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
             abort(403);
         }
 
@@ -88,15 +88,15 @@ class BudgetEntryController extends Controller
      */
     public function update(Request $request, BudgetEntry $budgetEntry)
     {
-        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
             abort(403);
         }
 
         $validated = $request->validate([
             'description' => 'required|string|max:255',
-            'amount'      => 'required|numeric',
-            'entry_date'  => 'required|date',
-            'category'    => 'nullable|string|max:255',
+            'amount' => 'required|numeric',
+            'entry_date' => 'required|date',
+            'category' => 'nullable|string|max:255',
         ]);
 
         $budgetEntry->update($validated);
@@ -109,7 +109,7 @@ class BudgetEntryController extends Controller
      */
     public function destroy(BudgetEntry $budgetEntry)
     {
-        if (!$budgetEntry->itinerary || $budgetEntry->itinerary->user_id !== Auth::id()) {
+        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
             abort(403);
         }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,13 +1,13 @@
 <?php
 
-use App\Http\Controllers\ProfileController;
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ActivityController;
-use App\Http\Controllers\ItineraryController;
+use App\Http\Controllers\BookingController;
+use App\Http\Controllers\BudgetEntryController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\GroupMemberController;
-use App\Http\Controllers\BudgetEntryController;
-use App\Http\Controllers\BookingController;
+use App\Http\Controllers\ItineraryController;
+use App\Http\Controllers\ProfileController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
@@ -26,9 +26,11 @@ Route::middleware('auth')->group(function () {
 Route::middleware(['auth'])->group(function () {
     Route::resource('itineraries', ItineraryController::class);
     Route::resource('itineraries.activities', ActivityController::class)->shallow();
-    Route::resource('itineraries.group-members', GroupMemberController::class)->shallow()->only(['store','update','destroy']);
-    Route::resource('itineraries.budgets', BudgetEntryController::class)->shallow();
-    Route::resource('itineraries.bookings', BookingController::class)->shallow()->only(['store','update','destroy']);
+    Route::resource('itineraries.group-members', GroupMemberController::class)->shallow()->only(['store', 'update', 'destroy']);
+    Route::resource('itineraries.budgets', BudgetEntryController::class)
+        ->shallow()
+        ->parameters(['budgets' => 'budgetEntry']);
+    Route::resource('itineraries.bookings', BookingController::class)->shallow()->only(['store', 'update', 'destroy']);
 });
 
 Route::middleware(['auth'])->group(function () {

--- a/tests/Feature/BudgetEntryTest.php
+++ b/tests/Feature/BudgetEntryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BudgetEntry;
+use App\Models\Itinerary;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BudgetEntryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_edit_own_budget_entry(): void
+    {
+        $user = User::factory()->create();
+
+        $itinerary = Itinerary::create([
+            'user_id' => $user->id,
+            'title' => 'Sample Trip',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addDay()->toDateString(),
+        ]);
+
+        $entry = BudgetEntry::create([
+            'itinerary_id' => $itinerary->id,
+            'description' => 'Lunch',
+            'amount' => 25.00,
+            'entry_date' => now()->toDateString(),
+            'category' => 'Food',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('budgets.edit', $entry->id));
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- fix budget route model binding and ownership check to avoid 403 errors when editing
- add regression test for editing budget entries

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688dcfec891c8329bcc33fa65d3cdf51