### PR TITLE
Refine budget overview layouts

### DIFF
--- a/resources/views/budgets/index.blade.php
+++ b/resources/views/budgets/index.blade.php
@@ -5,30 +5,33 @@
         </h2>
     </x-slot>
 
-    <div class="py-6 max-w-3xl mx-auto space-y-6">
-        <form method="POST" action="{{ route('itineraries.budgets.store', $itinerary->id) }}" class="space-y-2">
-            @csrf
-            <input type="hidden" name="itinerary_id" value="{{ $itinerary->id }}">
-            <div>
-                <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Description <span class="text-red-500">*</span></label>
-                <input type="text" id="description" name="description" placeholder="Description" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            </div>
-            <div>
-                <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Amount <span class="text-red-500">*</span></label>
-                <input type="number" step="0.01" id="amount" name="amount" placeholder="Amount" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            </div>
-            <div>
-                <label for="entry_date" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Date <span class="text-red-500">*</span></label>
-                <input type="date" id="entry_date" name="entry_date" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            </div>
-            <div>
-                <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
-                <input type="text" id="category" name="category" placeholder="Category" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
-            </div>
-            <div class="text-right">
-                <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Add</button>
-            </div>
-        </form>
+    <div class="py-6 max-w-7xl mx-auto space-y-6">
+        <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6">
+            <h3 class="text-lg font-semibold mb-4">Add Budget Entry</h3>
+            <form method="POST" action="{{ route('itineraries.budgets.store', $itinerary->id) }}" class="space-y-2">
+                @csrf
+                <input type="hidden" name="itinerary_id" value="{{ $itinerary->id }}">
+                <div>
+                    <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Description <span class="text-red-500">*</span></label>
+                    <input type="text" id="description" name="description" placeholder="Description" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                </div>
+                <div>
+                    <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Amount <span class="text-red-500">*</span></label>
+                    <input type="number" step="0.01" id="amount" name="amount" placeholder="Amount" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                </div>
+                <div>
+                    <label for="entry_date" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Date <span class="text-red-500">*</span></label>
+                    <input type="date" id="entry_date" name="entry_date" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                </div>
+                <div>
+                    <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
+                    <input type="text" id="category" name="category" placeholder="Category" class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+                </div>
+                <div class="text-right">
+                    <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Add</button>
+                </div>
+            </form>
+        </div>
 
         @if($categories->count())
             <form method="GET" class="text-right">
@@ -43,51 +46,63 @@
         @endif
 
         @if($itinerary->budgetEntries->count())
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead>
-                    <tr class="text-left">
-                        <th class="py-2">Description</th>
-                        <th class="py-2">Amount</th>
-                        <th class="py-2">Date</th>
-                        <th class="py-2">Category</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                    @foreach($itinerary->budgetEntries as $entry)
-                        <tr>
-                            <td class="py-2">{{ $entry->description }}</td>
-                            <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
-                            <td class="py-2">{{ $entry->entry_date }}</td>
-                            <td class="py-2">{{ $entry->category }}</td>
-                            <td class="py-2 text-right">
-                                <div class="flex items-center justify-end gap-2">
-                                    <a href="{{ route('budgets.edit', $entry->id) }}" class="inline-flex items-center px-2 py-1 bg-gray-500 hover:bg-gray-600 text-white rounded text-xs">Edit</a>
-                                    <form method="POST" action="{{ route('budgets.destroy', $entry->id) }}" class="inline-block">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs">Delete</button>
-                                    </form>
-                                </div>
-                            </td>
-                        </tr>
-                    @endforeach
-                </tbody>
-            </table>
-
-            @php
-                $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
-            @endphp
-            <p class="text-right font-semibold mt-2">Total Spent: PHP{{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}</p>
-            <ul class="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                @foreach($categoryTotals as $category => $total)
-                    <li>{{ $category }}: PHP{{ number_format($total, 2) }}</li>
-                @endforeach
-            </ul>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <x-budget-chart :entries="$itinerary->budgetEntries" />
-                <x-budget-category-chart :entries="$itinerary->budgetEntries" />
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div class="lg:col-span-2">
+                    <h3 class="text-lg font-semibold mb-3">Budget Entries</h3>
+                    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                        <thead>
+                            <tr class="text-left">
+                                <th class="py-2">Description</th>
+                                <th class="py-2">Amount</th>
+                                <th class="py-2">Date</th>
+                                <th class="py-2">Category</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach($itinerary->budgetEntries as $entry)
+                                <tr>
+                                    <td class="py-2">{{ $entry->description }}</td>
+                                    <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
+                                    <td class="py-2">{{ $entry->entry_date }}</td>
+                                    <td class="py-2">{{ $entry->category }}</td>
+                                    <td class="py-2 text-right">
+                                        <div class="flex items-center justify-end gap-2">
+                                            <a href="{{ route('budgets.edit', $entry->id) }}" class="inline-flex items-center px-2 py-1 bg-gray-500 hover:bg-gray-600 text-white rounded text-xs">Edit</a>
+                                            <form method="POST" action="{{ route('budgets.destroy', $entry->id) }}" class="inline-block">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs">Delete</button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                <div class="space-y-6">
+                    @php
+                        $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
+                    @endphp
+                    <div class="bg-gray-50 dark:bg-gray-900 p-4 rounded-lg">
+                        <h4 class="font-semibold mb-2">Summary</h4>
+                        <p class="text-right font-semibold">Total Spent: PHP{{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}</p>
+                        <ul class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                            @foreach($categoryTotals as $category => $total)
+                                <li>{{ $category }}: PHP{{ number_format($total, 2) }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    <div class="bg-gray-50 dark:bg-gray-900 p-4 rounded-lg">
+                        <h4 class="font-semibold mb-2">Spending Over Time</h4>
+                        <x-budget-chart :entries="$itinerary->budgetEntries" />
+                    </div>
+                    <div class="bg-gray-50 dark:bg-gray-900 p-4 rounded-lg">
+                        <h4 class="font-semibold mb-2">By Category</h4>
+                        <x-budget-category-chart :entries="$itinerary->budgetEntries" />
+                    </div>
+                </div>
             </div>
         @else
             <p class="text-gray-500 dark:text-gray-400">No budget entries yet.</p>

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -11,63 +11,77 @@
         <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6">
             <h3 class="text-lg font-semibold text-gray-800 dark:text-white mb-4">Budget Overview</h3>
             @if($itinerary->budgetEntries->count())
-                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 mb-4">
-                    <thead>
-                        <tr class="text-left">
-                            <th class="py-2">Description</th>
-                            <th class="py-2">Amount</th>
-                            <th class="py-2">Date</th>
-                            <th class="py-2">Category</th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                        @foreach($itinerary->budgetEntries as $entry)
-                            <tr>
-                                <td class="py-2">{{ $entry->description }}</td>
-                                <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
-                                <td class="py-2">{{ $entry->entry_date }}</td>
-                                <td class="py-2">{{ $entry->category }}</td>
-                            </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-                <x-budget-chart :entries="$itinerary->budgetEntries" />
-                <x-budget-category-chart :entries="$itinerary->budgetEntries" />
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                    <div class="lg:col-span-2">
+                        <h4 class="text-md font-semibold mb-2">Entries</h4>
+                        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 mb-4">
+                            <thead>
+                                <tr class="text-left">
+                                    <th class="py-2">Description</th>
+                                    <th class="py-2">Amount</th>
+                                    <th class="py-2">Date</th>
+                                    <th class="py-2">Category</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                                @foreach($itinerary->budgetEntries as $entry)
+                                    <tr>
+                                        <td class="py-2">{{ $entry->description }}</td>
+                                        <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
+                                        <td class="py-2">{{ $entry->entry_date }}</td>
+                                        <td class="py-2">{{ $entry->category }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="space-y-6">
+                        <div>
+                            <h4 class="text-md font-semibold mb-2">Spending Over Time</h4>
+                            <x-budget-chart :entries="$itinerary->budgetEntries" />
+                        </div>
+                        <div>
+                            <h4 class="text-md font-semibold mb-2">By Category</h4>
+                            <x-budget-category-chart :entries="$itinerary->budgetEntries" />
+                        </div>
+                    </div>
+                </div>
                 @php
                     $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
                     $topCategory = $categoryTotals->sortDesc()->keys()->first();
                     $totalSpent = $itinerary->budgetEntries->sum('amount');
                 @endphp
-                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 mt-4 text-sm text-gray-600 dark:text-gray-300">
-                    <thead>
-                        <tr class="text-left">
-                            <th class="py-2">Category</th>
-                            <th class="py-2">Amount</th>
-                            <th class="py-2">Percent</th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                        @foreach($categoryTotals as $category => $total)
-                            <tr @if($category === $topCategory) class="font-semibold" @endif>
-                                <td class="py-2">{{ $category }}</td>
-                                <td class="py-2">PHP{{ number_format($total, 2) }}</td>
-                                <td class="py-2">{{ round($total / $totalSpent * 100, 1) }}%</td>
+                <div class="mt-6">
+                    <h4 class="text-md font-semibold mb-2">Category Breakdown</h4>
+                    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm text-gray-600 dark:text-gray-300">
+                        <thead>
+                            <tr class="text-left">
+                                <th class="py-2">Category</th>
+                                <th class="py-2">Amount</th>
+                                <th class="py-2">Percent</th>
                             </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-                <p class="text-sm text-gray-600 dark:text-gray-300 mt-4">
-                    Top spending category: {{ $topCategory }} (PHP{{ number_format($categoryTotals[$topCategory], 2) }})
-                </p>
-                <p class="text-sm text-gray-600 dark:text-gray-300 mt-4">
-                    Total: PHP{{ number_format($totalSpent, 2) }}
-                </p>
-                @if($averageBudget)
-                    <p class="text-sm text-gray-600 dark:text-gray-300">
-                        Average budget for itineraries with activities in {{ $primaryLocation }}: PHP{{ number_format($averageBudget, 2) }}
-                        ({{ round(($totalSpent - $averageBudget) / $averageBudget * 100, 1) }}% {{ $totalSpent >= $averageBudget ? 'above' : 'below' }} average)
-                    </p>
-                @endif
+                        </thead>
+                        <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach($categoryTotals as $category => $total)
+                                <tr @if($category === $topCategory) class="font-semibold" @endif>
+                                    <td class="py-2">{{ $category }}</td>
+                                    <td class="py-2">PHP{{ number_format($total, 2) }}</td>
+                                    <td class="py-2">{{ round($total / $totalSpent * 100, 1) }}%</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                <div class="mt-4 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+                    <p>Top spending category: {{ $topCategory }} (PHP{{ number_format($categoryTotals[$topCategory], 2) }})</p>
+                    <p>Total: PHP{{ number_format($totalSpent, 2) }}</p>
+                    @if($averageBudget)
+                        <p>
+                            Average budget for itineraries with activities in {{ $primaryLocation }}: PHP{{ number_format($averageBudget, 2) }}
+                            ({{ round(($totalSpent - $averageBudget) / $averageBudget * 100, 1) }}% {{ $totalSpent >= $averageBudget ? 'above' : 'below' }} average)
+                        </p>
+                    @endif
+                </div>
             @else
                 <p class="text-gray-500 dark:text-gray-400">No budget entries yet.</p>
             @endif


### PR DESCRIPTION
## Summary
- Improve budget entry page with card-based form and grid layout, including summary and charts
- Rework itinerary budget overview to present entries, charts, and category breakdown in a structured grid

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688dd2dab2388329a86de0505122deaf