### PR TITLE
Add framed photos with SVG fallbacks

### DIFF
--- a/public/images/default-photo.svg
+++ b/public/images/default-photo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <rect width="100" height="100" fill="#e5e7eb"/>
+  <path d="M30 40c0-8 6-14 14-14s14 6 14 14-6 14-14 14S30 48 30 40z" fill="#9ca3af"/>
+  <path d="M20 80c0-10 8-18 18-18h24c10 0 18 8 18 18v4H20v-4z" fill="#9ca3af"/>
+</svg>

--- a/resources/views/components/group-member-list.blade.php
+++ b/resources/views/components/group-member-list.blade.php
@@ -1,12 +1,20 @@
 @props(['members'])
 <ul class="mt-4 space-y-2">
     @foreach($members as $member)
-        <li x-data="{ openEdit: false, openDelete: false }" class="flex justify-between items-center bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
-            <div>
-                <p class="text-sm font-medium text-gray-800 dark:text-white">{{ $member->name }}</p>
-                @if($member->notes)
-                    <p class="text-xs text-gray-500 dark:text-gray-300">{{ $member->notes }}</p>
-                @endif
+        @php
+            $photo = $member->photo_path
+                ? Storage::url($member->photo_path)
+                : asset('images/default-photo.svg');
+        @endphp
+        <li x-data="{ openEdit: false, openDelete: false }" class="flex items-center justify-between bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
+            <div class="flex items-center gap-3">
+                <img src="{{ $photo }}" alt="{{ $member->name }}" class="w-10 h-10 rounded-full object-cover border-2 border-gray-300 dark:border-gray-600">
+                <div>
+                    <p class="text-sm font-medium text-gray-800 dark:text-white">{{ $member->name }}</p>
+                    @if($member->notes)
+                        <p class="text-xs text-gray-500 dark:text-gray-300">{{ $member->notes }}</p>
+                    @endif
+                </div>
             </div>
             <div class="flex items-center gap-2">
                 <button @click.prevent="openEdit = true"

--- a/resources/views/components/itinerary-card.blade.php
+++ b/resources/views/components/itinerary-card.blade.php
@@ -12,18 +12,26 @@
         activity      : {},
         booking       : {}
     }" class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 space-y-4">
-    <!-- ── Title & Info ─────────────────────────────────────────────── -->
+    @php
+        $photo = $itinerary->photo_path
+            ? Storage::url($itinerary->photo_path)
+            : asset('images/default-photo.svg');
+    @endphp
+    <!-- ── Title, Photo & Info ───────────────────────────────────────── -->
     <div class="flex justify-between items-start">
-        <div>
-            <h3 class="text-xl font-semibold text-gray-800 dark:text-white">
-                {{ $itinerary->title }}
-            </h3>
-            <p class="text-sm text-gray-600 dark:text-gray-300">
-                {{ $itinerary->description }}
-            </p>
-            <p class="text-sm text-gray-500 dark:text-gray-400">
-                {{ $itinerary->start_date }} to {{ $itinerary->end_date }}
-            </p>
+        <div class="flex gap-4">
+            <img src="{{ $photo }}" alt="{{ $itinerary->title }}" class="w-24 h-24 object-cover rounded-md border-2 border-gray-300 dark:border-gray-600">
+            <div>
+                <h3 class="text-xl font-semibold text-gray-800 dark:text-white">
+                    {{ $itinerary->title }}
+                </h3>
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                    {{ $itinerary->description }}
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                    {{ $itinerary->start_date }} to {{ $itinerary->end_date }}
+                </p>
+            </div>
         </div>
         @if($showActions)
             <div class="flex items-center gap-2 text-sm">


### PR DESCRIPTION
## Summary
- Display itinerary photo with bordered frame and use SVG placeholder when missing
- Show group member avatars with default SVG and styled frame
- Include generic default-photo.svg asset

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688dd5c7e00c83299a135948871694ae