### PR TITLE
fix: ensure budget chart data is array

### DIFF
--- a/resources/views/components/budget-chart.blade.php
+++ b/resources/views/components/budget-chart.blade.php
@@ -11,7 +11,7 @@
         const data = @json($entries->sortBy('entry_date')->map(fn($e) => [
             'date' => $e->entry_date->format('Y-m-d'),
             'amount' => (float) $e->amount,
-        ]));
+        ])->values());
 
         const colors = ['#60a5fa', '#34d399', '#fbbf24', '#f87171', '#a78bfa'];
 


### PR DESCRIPTION
## Summary
- fix budget chart component to serialize entries as array for JS

## Testing
- `npm test` (fails: Missing script: "test")
- `composer test` (warnings: Failed to open stream: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_688dd7b329f08329a82b9fe9dbffc624