### PR TITLE
Add spent amount tracking for budget entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ composer test
 - `routes/web.php` – web routes for the application
 
 ## Budget Tracking
-Each itinerary has a budget page where you can log expenses. Entries can be edited or deleted, and the page displays the total spent along with helpful charts.
+Each itinerary has a budget page where you can log expenses. Entries track both budgeted and spent amounts, and a dedicated "Update Spent" action lets you adjust actual spending. The page displays the total spent along with helpful charts.
 You can also filter entries by category to focus on specific types of spending.
 
 ## Contributing

--- a/app/Http/Controllers/BudgetEntryController.php
+++ b/app/Http/Controllers/BudgetEntryController.php
@@ -54,6 +54,8 @@ class BudgetEntryController extends Controller
             'category' => 'nullable|string|max:255',
         ]);
 
+        $validated['spent_amount'] = 0;
+
         BudgetEntry::create($validated);
 
         return back()->with('success', 'Entry added.');
@@ -116,5 +118,29 @@ class BudgetEntryController extends Controller
         $budgetEntry->delete();
 
         return back()->with('success', 'Entry removed.');
+    }
+
+    public function editSpent(BudgetEntry $budgetEntry)
+    {
+        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
+            abort(403);
+        }
+
+        return view('budgets.edit-spent', compact('budgetEntry'));
+    }
+
+    public function updateSpent(Request $request, BudgetEntry $budgetEntry)
+    {
+        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'spent_amount' => 'required|numeric|min:0',
+        ]);
+
+        $budgetEntry->update($validated);
+
+        return back()->with('success', 'Spent amount updated.');
     }
 }

--- a/app/Models/BudgetEntry.php
+++ b/app/Models/BudgetEntry.php
@@ -10,6 +10,7 @@ class BudgetEntry extends Model
         'itinerary_id',
         'description',
         'amount',
+        'spent_amount',
         'entry_date',
         'category',
     ];
@@ -22,6 +23,7 @@ class BudgetEntry extends Model
         return [
             'entry_date' => 'date',
             'amount' => 'float',
+            'spent_amount' => 'float',
         ];
     }
 

--- a/database/migrations/2025_08_02_000000_add_spent_amount_to_budget_entries_table.php
+++ b/database/migrations/2025_08_02_000000_add_spent_amount_to_budget_entries_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('budget_entries', function (Blueprint $table) {
+            $table->decimal('spent_amount', 8, 2)->default(0)->after('amount');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('budget_entries', function (Blueprint $table) {
+            $table->dropColumn('spent_amount');
+        });
+    }
+};

--- a/resources/views/budgets/edit-spent.blade.php
+++ b/resources/views/budgets/edit-spent.blade.php
@@ -1,0 +1,21 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Update Spent Amount
+        </h2>
+    </x-slot>
+
+    <div class="py-6 max-w-xl mx-auto">
+        <form method="POST" action="{{ route('budgets.update-spent', $budgetEntry->id) }}" class="space-y-2">
+            @csrf
+            @method('PATCH')
+            <div>
+                <label for="spent_amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Spent Amount <span class="text-red-500">*</span></label>
+                <input type="number" step="0.01" id="spent_amount" name="spent_amount" value="{{ old('spent_amount', $budgetEntry->spent_amount) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
+            </div>
+            <div class="text-right">
+                <button class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Update</button>
+            </div>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/budgets/edit.blade.php
+++ b/resources/views/budgets/edit.blade.php
@@ -14,7 +14,7 @@
                 <input type="text" id="description" name="description" value="{{ old('description', $budgetEntry->description) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
             </div>
             <div>
-                <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Amount <span class="text-red-500">*</span></label>
+                <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Budget Amount <span class="text-red-500">*</span></label>
                 <input type="number" step="0.01" id="amount" name="amount" value="{{ old('amount', $budgetEntry->amount) }}" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
             </div>
             <div>

--- a/resources/views/budgets/index.blade.php
+++ b/resources/views/budgets/index.blade.php
@@ -16,7 +16,7 @@
                     <input type="text" id="description" name="description" placeholder="Description" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
                 </div>
                 <div>
-                    <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Amount <span class="text-red-500">*</span></label>
+                    <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Budget Amount <span class="text-red-500">*</span></label>
                     <input type="number" step="0.01" id="amount" name="amount" placeholder="Amount" required class="w-full px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-gray-300">
                 </div>
                 <div>
@@ -53,7 +53,8 @@
                         <thead>
                             <tr class="text-left">
                                 <th class="py-2">Description</th>
-                                <th class="py-2">Amount</th>
+                                <th class="py-2">Budgeted</th>
+                                <th class="py-2">Spent</th>
                                 <th class="py-2">Date</th>
                                 <th class="py-2">Category</th>
                                 <th></th>
@@ -64,11 +65,13 @@
                                 <tr>
                                     <td class="py-2">{{ $entry->description }}</td>
                                     <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
+                                    <td class="py-2">PHP{{ number_format($entry->spent_amount, 2) }}</td>
                                     <td class="py-2">{{ $entry->entry_date }}</td>
                                     <td class="py-2">{{ $entry->category }}</td>
                                     <td class="py-2 text-right">
                                         <div class="flex items-center justify-end gap-2">
                                             <a href="{{ route('budgets.edit', $entry->id) }}" class="inline-flex items-center px-2 py-1 bg-gray-500 hover:bg-gray-600 text-white rounded text-xs">Edit</a>
+                                            <a href="{{ route('budgets.edit-spent', $entry->id) }}" class="inline-flex items-center px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white rounded text-xs">Update Spent</a>
                                             <form method="POST" action="{{ route('budgets.destroy', $entry->id) }}" class="inline-block">
                                                 @csrf
                                                 @method('DELETE')
@@ -83,11 +86,11 @@
                 </div>
                 <div class="space-y-6">
                     @php
-                        $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
+                        $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('spent_amount');
                     @endphp
                     <div class="bg-gray-50 dark:bg-gray-900 p-4 rounded-lg">
                         <h4 class="font-semibold mb-2">Summary</h4>
-                        <p class="text-right font-semibold">Total Spent: PHP{{ number_format($itinerary->budgetEntries->sum('amount'), 2) }}</p>
+                        <p class="text-right font-semibold">Total Spent: PHP{{ number_format($itinerary->budgetEntries->sum('spent_amount'), 2) }}</p>
                         <ul class="mt-2 text-sm text-gray-600 dark:text-gray-300">
                             @foreach($categoryTotals as $category => $total)
                                 <li>{{ $category }}: PHP{{ number_format($total, 2) }}</li>

--- a/resources/views/budgets/show.blade.php
+++ b/resources/views/budgets/show.blade.php
@@ -7,7 +7,8 @@
 
     <div class="py-6 max-w-xl mx-auto space-y-4">
         <p><strong>Description:</strong> {{ $budgetEntry->description }}</p>
-        <p><strong>Amount:</strong> PHP{{ number_format($budgetEntry->amount,2) }}</p>
+        <p><strong>Budgeted:</strong> PHP{{ number_format($budgetEntry->amount,2) }}</p>
+        <p><strong>Spent:</strong> PHP{{ number_format($budgetEntry->spent_amount,2) }}</p>
         <p><strong>Date:</strong> {{ $budgetEntry->entry_date }}</p>
         <p><strong>Category:</strong> {{ $budgetEntry->category }}</p>
     </div>

--- a/resources/views/components/budget-category-chart.blade.php
+++ b/resources/views/components/budget-category-chart.blade.php
@@ -8,7 +8,7 @@
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         const ctx = document.getElementById('budget-category-chart');
-        const data = @json($entries->groupBy('category')->map(fn($items) => $items->sum('amount')));
+        const data = @json($entries->groupBy('category')->map(fn($items) => $items->sum('spent_amount')));
         new Chart(ctx, {
             type: 'doughnut',
             data: {

--- a/resources/views/components/budget-chart.blade.php
+++ b/resources/views/components/budget-chart.blade.php
@@ -10,7 +10,7 @@
         const ctx = document.getElementById('budget-chart');
         const data = @json($entries->sortBy('entry_date')->map(fn($e) => [
             'date' => $e->entry_date->format('Y-m-d'),
-            'amount' => (float) $e->amount,
+            'amount' => (float) $e->spent_amount,
         ]));
 
         const colors = ['#60a5fa', '#34d399', '#fbbf24', '#f87171', '#a78bfa'];
@@ -20,7 +20,7 @@
             data: {
                 labels: data.map(d => d.date),
                 datasets: [{
-                    label: 'Amount',
+                    label: 'Spent',
                     data: data.map(d => d.amount),
                     backgroundColor: data.map((_, i) => colors[i % colors.length]),
                 }]

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -18,7 +18,8 @@
                             <thead>
                                 <tr class="text-left">
                                     <th class="py-2">Description</th>
-                                    <th class="py-2">Amount</th>
+                                    <th class="py-2">Budgeted</th>
+                                    <th class="py-2">Spent</th>
                                     <th class="py-2">Date</th>
                                     <th class="py-2">Category</th>
                                 </tr>
@@ -28,6 +29,7 @@
                                     <tr>
                                         <td class="py-2">{{ $entry->description }}</td>
                                         <td class="py-2">PHP{{ number_format($entry->amount, 2) }}</td>
+                                        <td class="py-2">PHP{{ number_format($entry->spent_amount, 2) }}</td>
                                         <td class="py-2">{{ $entry->entry_date }}</td>
                                         <td class="py-2">{{ $entry->category }}</td>
                                     </tr>
@@ -47,9 +49,9 @@
                     </div>
                 </div>
                 @php
-                    $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('amount');
+                    $categoryTotals = $itinerary->budgetEntries->groupBy('category')->map->sum('spent_amount');
                     $topCategory = $categoryTotals->sortDesc()->keys()->first();
-                    $totalSpent = $itinerary->budgetEntries->sum('amount');
+                    $totalSpent = $itinerary->budgetEntries->sum('spent_amount');
                 @endphp
                 <div class="mt-6">
                     <h4 class="text-md font-semibold mb-2">Category Breakdown</h4>
@@ -57,7 +59,7 @@
                         <thead>
                             <tr class="text-left">
                                 <th class="py-2">Category</th>
-                                <th class="py-2">Amount</th>
+                                <th class="py-2">Spent</th>
                                 <th class="py-2">Percent</th>
                             </tr>
                         </thead>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,8 @@ Route::middleware(['auth'])->group(function () {
     Route::resource('itineraries.budgets', BudgetEntryController::class)
         ->shallow()
         ->parameters(['budgets' => 'budgetEntry']);
+    Route::get('budgets/{budgetEntry}/spent', [BudgetEntryController::class, 'editSpent'])->name('budgets.edit-spent');
+    Route::patch('budgets/{budgetEntry}/spent', [BudgetEntryController::class, 'updateSpent'])->name('budgets.update-spent');
     Route::resource('itineraries.bookings', BookingController::class)->shallow()->only(['store', 'update', 'destroy']);
 });
 


### PR DESCRIPTION
## Summary
- track actual spending by adding `spent_amount` field to budget entries
- allow updating spent amounts with new routes, views, and button on budget list
- visualize spending using updated charts and summaries

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_688dd79735648329a2d8326d8d7ea652