### PR TITLE
Add photo support for activities

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Models\Itinerary;
 class ActivityController extends Controller
 {
-    protected $fillable = ['title', 'note', 'scheduled_at', 'location', 'latitude', 'longitude', 'itinerary_id'];
+    protected $fillable = ['title', 'note', 'scheduled_at', 'location', 'latitude', 'longitude', 'photo_path', 'itinerary_id'];
 
     /**
      * Display a listing of the resource.
@@ -45,9 +45,10 @@ class ActivityController extends Controller
             'scheduled_at' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
             'latitude' => 'nullable|numeric',
             'longitude' => 'nullable|numeric',
+            'photo' => 'nullable|image|max:2048',
         ]);
 
-        Activity::create([
+        $data = [
             'itinerary_id' => $request->itinerary_id,
             'title' => $request->title,
             'location' => $request->location,
@@ -58,7 +59,13 @@ class ActivityController extends Controller
             'scheduled_at' => $request->scheduled_at,
             'latitude' => $request->latitude,
             'longitude' => $request->longitude,
-        ]);
+        ];
+
+        if ($request->hasFile('photo')) {
+            $data['photo_path'] = $request->file('photo')->store('activities', 'public');
+        }
+
+        Activity::create($data);
 
         return redirect()->back()->with('success', 'Activity added.');
     }
@@ -100,7 +107,12 @@ class ActivityController extends Controller
             'note'         => 'nullable|string',
             'latitude'     => 'nullable|numeric',
             'longitude'    => 'nullable|numeric',
+            'photo'        => 'nullable|image|max:2048',
         ]);
+
+        if ($request->hasFile('photo')) {
+            $validated['photo_path'] = $request->file('photo')->store('activities', 'public');
+        }
 
         $activity->update($validated);
 

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -18,6 +18,7 @@ class Activity extends Model
         'attire_note',
         'latitude',
         'longitude',
+        'photo_path',
     ];
 
     public function itinerary()

--- a/database/migrations/2025_07_31_160000_add_photo_path_to_activities_table.php
+++ b/database/migrations/2025_07_31_160000_add_photo_path_to_activities_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->string('photo_path')->nullable()->after('location');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropColumn('photo_path');
+        });
+    }
+};

--- a/resources/views/activity/activity-form.blade.php
+++ b/resources/views/activity/activity-form.blade.php
@@ -21,6 +21,7 @@
             ? ('/activities/' + activity.id)          /* PUT  → /activities/{id} */
             : '{{ route('activities.store') }}'        /* POST → /activities      */"
         method="POST"
+        enctype="multipart/form-data"
         class="space-y-6"
     >
         @csrf
@@ -37,6 +38,16 @@
 
         <!-- ── form grid ─────────────────────────────────────── -->
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+
+            <!-- Photo upload -->
+            <div class="flex flex-col space-y-1 sm:col-span-2">
+                <label class="font-medium text-gray-700 dark:text-gray-300">Photo</label>
+                <template x-if="activity.photo_path">
+                    <img :src="'/storage/' + activity.photo_path" alt="Activity photo" class="h-40 w-full object-cover rounded-md mb-2" />
+                </template>
+                <input type="file" name="photo"
+                       class="px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 dark:text-white ring-1 ring-inset ring-gray-300 focus:ring-primary focus:ring-2 outline-none" />
+            </div>
 
             <!-- Title -->
             <div class="flex flex-col space-y-1">

--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -10,7 +10,7 @@
 @foreach ($sorted as $index => $activity)
     <li
         x-data="{ openDelete: false }"
-        class="pt-3 first:pt-0 grid grid-cols-[auto_1fr_auto] gap-3
+        class="pt-3 first:pt-0 grid grid-cols-[auto_auto_1fr_auto] gap-3
                hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition"
         data-marker-id="marker-{{ $activity->id }}"
     >
@@ -20,6 +20,15 @@
                    text-xs font-bold bg-primary text-white dark:bg-primary-light">
             {{ $index + 1 }}
         </span>
+
+        {{-- Photo --}}
+        <div class="self-center">
+            @if ($activity->photo_path)
+                <img src="{{ asset('storage/' . $activity->photo_path) }}" alt="{{ $activity->title }} photo" class="w-12 h-12 object-cover rounded-md">
+            @else
+                <div class="w-12 h-12 flex items-center justify-center rounded-md bg-gray-200 dark:bg-gray-700 text-gray-500 text-xs">N/A</div>
+            @endif
+        </div>
 
         {{-- Activity meta --}}
         <div class="min-w-0">


### PR DESCRIPTION
## Summary
- allow uploading a photo for an activity and persist path
- display existing photo and upload control in activity form
- show activity thumbnails in activity lists

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dd8db7b68832980d98ec4afe664ff