### PR TITLE
Prevent division by zero in itinerary budget display

### DIFF
--- a/resources/views/components/budget-chart.blade.php
+++ b/resources/views/components/budget-chart.blade.php
@@ -10,19 +10,20 @@
         const ctx = document.getElementById('budget-chart');
         const data = @json($entries->sortBy('entry_date')->map(fn($e) => [
             'date' => $e->entry_date->format('Y-m-d'),
-            'amount' => (float) $e->amount,
+            'amount' => (float) ($e->spent_amount ?? 0),
         ])->values());
 
-        const colors = ['#60a5fa', '#34d399', '#fbbf24', '#f87171', '#a78bfa'];
-
         new Chart(ctx, {
-            type: 'bar',
+            type: 'line',
             data: {
                 labels: data.map(d => d.date),
                 datasets: [{
                     label: 'Spent',
                     data: data.map(d => d.amount),
-                    backgroundColor: data.map((_, i) => colors[i % colors.length]),
+                    borderColor: '#60a5fa',
+                    backgroundColor: '#60a5fa33',
+                    fill: false,
+                    tension: 0.4,
                 }]
             },
             options: {

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -68,7 +68,7 @@
                                 <tr @if($category === $topCategory) class="font-semibold" @endif>
                                     <td class="py-2">{{ $category }}</td>
                                     <td class="py-2">PHP{{ number_format($total, 2) }}</td>
-                                    <td class="py-2">{{ round($total / $totalSpent * 100, 1) }}%</td>
+                                    <td class="py-2">{{ $totalSpent > 0 ? round($total / $totalSpent * 100, 1) : 0 }}%</td>
                                 </tr>
                             @endforeach
                         </tbody>


### PR DESCRIPTION
## Summary
- Avoid dividing by zero when computing category percentages in itinerary view
- Show spending over time as a line chart using actual spent amounts

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test` *(warnings: missing .env file)*
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688dd930d6b48329af70441647a45ff8