### PR TITLE
Add dynamic page titles across views

### DIFF
--- a/app/View/Components/AppLayout.php
+++ b/app/View/Components/AppLayout.php
@@ -8,6 +8,14 @@ use Illuminate\View\View;
 class AppLayout extends Component
 {
     /**
+     * Create a new component instance.
+     */
+    public function __construct(public ?string $title = null)
+    {
+        //
+    }
+
+    /**
      * Get the view / contents that represents the component.
      */
     public function render(): View

--- a/app/View/Components/GuestLayout.php
+++ b/app/View/Components/GuestLayout.php
@@ -8,6 +8,14 @@ use Illuminate\View\View;
 class GuestLayout extends Component
 {
     /**
+     * Create a new component instance.
+     */
+    public function __construct(public ?string $title = null)
+    {
+        //
+    }
+
+    /**
      * Get the view / contents that represents the component.
      */
     public function render(): View

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Confirm Password') }}">
     <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
         {{ __('This is a secure area of the application. Please confirm your password before continuing.') }}
     </div>

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Forgot Password') }}">
     <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
         {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
     </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Log in') }}">
     <!-- Session Status -->
     <x-auth-session-status class="mb-4" :status="session('status')" />
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Register') }}">
     <form method="POST" action="{{ route('register') }}">
         @csrf
 

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Reset Password') }}">
     <form method="POST" action="{{ route('password.store') }}">
         @csrf
 

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-guest-layout title="{{ __('Verify Email') }}">
     <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
         {{ __('Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn\'t receive the email, we will gladly send you another.') }}
     </div>

--- a/resources/views/budgets/edit-spent.blade.php
+++ b/resources/views/budgets/edit-spent.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Update Spent Amount">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             Update Spent Amount

--- a/resources/views/budgets/edit.blade.php
+++ b/resources/views/budgets/edit.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Edit Entry">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             Edit Entry

--- a/resources/views/budgets/index.blade.php
+++ b/resources/views/budgets/index.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ $itinerary->title }} - Budget">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             {{ $itinerary->title }} - Budget

--- a/resources/views/budgets/show.blade.php
+++ b/resources/views/budgets/show.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Budget Entry">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             Budget Entry

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout x-data="{ openForm: false }">
+<x-app-layout title="Dashboard" x-data="{ openForm: false }">
     <x-slot name="header">
         <div x-data="{ openForm: false }" class="flex items-center justify-between">
             <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">

--- a/resources/views/itineraries/create.blade.php
+++ b/resources/views/itineraries/create.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('Add Itinerary') }}">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             {{ __('Add Itinerary') }}

--- a/resources/views/itineraries/edit.blade.php
+++ b/resources/views/itineraries/edit.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('Edit Itinerary') }}">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             {{ __('Edit Itinerary') }}

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ $itinerary->title }}">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             {{ $itinerary->title }}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    <title>{{ config('app.name', 'Itinerary Planner') }}</title>
+    <title>{{ $title ? $title . ' - ' : '' }}{{ config('app.name', 'Itinerary Planner') }}</title>
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Itinenary App') }}</title>
+        <title>{{ $title ? $title . ' - ' : '' }}{{ config('app.name', 'Itinerary Planner') }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="{{ __('Profile') }}">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
             {{ __('Profile') }}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Itinerary Planner</title>
+        <title>Welcome - Itinerary Planner</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
## Summary
- allow layouts to accept a customizable `$title`
- use the title across guest and app layouts
- specify a unique page title for every view

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688ddb6207f08329b8dbb7f90c651822