### PR TITLE
Add server-side geocoding proxy with CORS configuration

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,15 +3,17 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\HandleCors;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(HandleCors::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+    'allowed_methods' => ['*'],
+    'allowed_origins' => ['*'],
+    'allowed_origins_patterns' => [],
+    'allowed_headers' => ['*'],
+    'exposed_headers' => [],
+    'max_age' => 0,
+    'supports_credentials' => false,
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Http\Request;
+
+Route::get('/reverse-geocode', function (Request $request) {
+    $response = Http::get('https://geocoding-api.open-meteo.com/v1/reverse', [
+        'latitude' => $request->query('latitude'),
+        'longitude' => $request->query('longitude'),
+        'count' => 1,
+    ]);
+
+    return $response->json();
+});
+


### PR DESCRIPTION
## Summary
- enable CORS globally and register API routing
- expose `/api/reverse-geocode` endpoint that proxies to Open Meteo
- add default `config/cors.php`

## Testing
- `composer test` *(fails: missing .env, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688de70ea03c8329814622fde1eaddd3