### PR TITLE
Fix missing DomPDF facade for itinerary PDFs

### DIFF
--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -8,7 +8,7 @@ use App\Models\BudgetEntry;
 use Illuminate\Support\Facades\Auth;
 use App\Exports\ItineraryExport;
 use Maatwebsite\Excel\Facades\Excel as ExcelFacade;
-use Barryvdh\DomPDF\Facade\Pdf as PdfFacade;
+use Barryvdh\DomPDF\Facade\Pdf;
 
 
 class ItineraryController extends Controller
@@ -167,7 +167,7 @@ class ItineraryController extends Controller
 
         $itinerary->load(['activities', 'groupMembers', 'bookings', 'budgetEntries']);
 
-        $pdf = PdfFacade::loadView('itineraries.export', [
+        $pdf = Pdf::loadView('itineraries.export', [
             'itinerary' => $itinerary,
         ]);
 


### PR DESCRIPTION
## Summary
- use DomPDF's `Pdf` facade for itinerary PDF export

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688de81668c48329ac40db822f1fb1e5