### PR TITLE
Fix Excel export missing facade

### DIFF
--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -7,7 +7,7 @@ use App\Models\Itinerary;
 use App\Models\BudgetEntry;
 use Illuminate\Support\Facades\Auth;
 use App\Exports\ItineraryExport;
-use Maatwebsite\Excel\Facades\Excel as ExcelFacade;
+use Maatwebsite\Excel\Facades\Excel;
 use Barryvdh\DomPDF\Facade\Pdf as PdfFacade;
 
 
@@ -156,7 +156,7 @@ class ItineraryController extends Controller
 
         $itinerary->load(['activities', 'groupMembers', 'bookings', 'budgetEntries']);
 
-        return ExcelFacade::download(new ItineraryExport($itinerary), 'itinerary.xlsx');
+        return Excel::download(new ItineraryExport($itinerary), 'itinerary.xlsx');
     }
 
     public function exportPdf(Itinerary $itinerary)


### PR DESCRIPTION
## Summary
- use built-in Excel facade to trigger Excel downloads

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688de8691b248329b690c899e522b59b