### PR TITLE
feat: make activity notes expandable

### DIFF
--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -42,9 +42,18 @@
             </p>
 
             @if ($activity->note)
-                <p class="text-xs italic text-gray-500 dark:text-gray-400 line-clamp-2">
-                    {{ $activity->note }}
-                </p>
+                <div x-data="{ expanded: false }">
+                    <p class="text-xs italic text-gray-500 dark:text-gray-400" :class="expanded ? '' : 'line-clamp-2'">
+                        {{ $activity->note }}
+                    </p>
+                    <button type="button"
+                            class="mt-1 text-[11px] text-primary hover:underline"
+                            @click="expanded = !expanded">
+                        <span x-show="!expanded">Show more</span>
+        
+                        <span x-show="expanded">Show less</span>
+                    </button>
+                </div>
             @endif
             @if ($activity->budget)
                 <p class="text-xs text-gray-500 dark:text-gray-400">Budget: PHP{{ number_format($activity->budget, 2) }}</p>


### PR DESCRIPTION
## Summary
- allow activity notes to expand/collapse with Show more/Show less toggle

## Testing
- `npm run build`
- `composer test` *(fails: file_get_contents(/workspace/itinerary-planner/.env): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891fd2c3f708329af7885f7426e1214