### PR TITLE
Paginate budget entries with Show more button

### DIFF
--- a/app/Http/Controllers/BudgetEntryController.php
+++ b/app/Http/Controllers/BudgetEntryController.php
@@ -18,20 +18,20 @@ class BudgetEntryController extends Controller
         $filter = $request->query('category');
 
         $itinerary = Itinerary::where('user_id', Auth::id())
-            ->with([
-                'budgetEntries' => function ($query) use ($filter) {
-                    $query->when($filter, fn ($q) => $q->where('category', $filter));
-                },
-                'groupMembers',
-            ])
+            ->with('groupMembers')
             ->findOrFail($itinerary);
+
+        $budgetEntries = BudgetEntry::where('itinerary_id', $itinerary->id)
+            ->when($filter, fn ($q) => $q->where('category', $filter))
+            ->paginate(10)
+            ->withQueryString();
 
         $categories = BudgetEntry::where('itinerary_id', $itinerary->id)
             ->pluck('category')
             ->filter()
             ->unique();
 
-        return view('budgets.index', compact('itinerary', 'categories', 'filter'));
+        return view('budgets.index', compact('itinerary', 'categories', 'filter', 'budgetEntries'));
     }
 
     /**

--- a/resources/views/budgets/index.blade.php
+++ b/resources/views/budgets/index.blade.php
@@ -67,7 +67,7 @@
             </form>
         @endif
 
-        @if($itinerary->budgetEntries->count())
+        @if($budgetEntries->count())
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 <div class="lg:col-span-2">
                     <h3 class="text-lg font-semibold mb-3">Budget Entries</h3>
@@ -84,7 +84,7 @@
                         </thead>
                         <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                             @php
-                                $groupedEntries = $itinerary->budgetEntries->sortBy('category')->groupBy('category');
+                                $groupedEntries = $budgetEntries->sortBy('category')->groupBy('category');
                                 $totals = ['budget' => 0, 'spent' => 0];
                             @endphp
                             @foreach($groupedEntries as $category => $entries)
@@ -154,10 +154,18 @@
                             </tr>
                         </tbody>
                     </table>
+                    <div class="mt-4">
+                        {{ $budgetEntries->links() }}
+                        @if($budgetEntries->hasMorePages())
+                            <div class="text-center mt-2">
+                                <a href="{{ $budgetEntries->nextPageUrl() }}" class="px-3 py-1 bg-primary hover:bg-primary-dark text-white rounded text-sm">Show more</a>
+                            </div>
+                        @endif
+                    </div>
                 </div>
                 <div class="space-y-6">
                     @php
-                        $entries = $itinerary->budgetEntries;
+                        $entries = $budgetEntries;
                         $categoryTotals = $entries->groupBy('category')->map->sum('spent_amount');
                         $totalBudget = $entries->sum('amount');
                         $totalSpent = $entries->sum('spent_amount');
@@ -174,11 +182,11 @@
                     </div>
                     <div class="bg-gray-50 dark:bg-gray-900 p-4 rounded-lg">
                         <h4 class="font-semibold mb-2">Spending Over Time</h4>
-                        <x-budget-chart :entries="$itinerary->budgetEntries" />
+                        <x-budget-chart :entries="$budgetEntries" />
                     </div>
                     <div class="bg-gray-50 dark:bg-gray-900 p-4 rounded-lg">
                         <h4 class="font-semibold mb-2">By Category</h4>
-                        <x-budget-category-chart :entries="$itinerary->budgetEntries" />
+                        <x-budget-category-chart :entries="$budgetEntries" />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Paginate budget entries instead of eager-loading them all
- Update budgets index view to iterate over paginated entries
- Render pagination links and add a "Show more" button for additional pages

## Testing
- `php artisan test` *(fails: file_get_contents(.env) missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891fd2cfb1083298c7f113f729b2d23