### PR TITLE
Track paid participants on budget entries

### DIFF
--- a/app/Models/BudgetEntry.php
+++ b/app/Models/BudgetEntry.php
@@ -14,6 +14,7 @@ class BudgetEntry extends Model
         'entry_date',
         'category',
         'participants',
+        'paid_participants',
     ];
 
     /**
@@ -26,6 +27,7 @@ class BudgetEntry extends Model
             'amount' => 'float',
             'spent_amount' => 'float',
             'participants' => 'array',
+            'paid_participants' => 'array',
         ];
     }
 

--- a/database/migrations/2025_08_04_000000_add_paid_participants_to_budget_entries_table.php
+++ b/database/migrations/2025_08_04_000000_add_paid_participants_to_budget_entries_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('budget_entries', function (Blueprint $table) {
+            $table->json('paid_participants')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('budget_entries', function (Blueprint $table) {
+            $table->dropColumn('paid_participants');
+        });
+    }
+};

--- a/resources/views/budgets/edit.blade.php
+++ b/resources/views/budgets/edit.blade.php
@@ -41,6 +41,17 @@
                         <span class="ml-1 text-sm">Include all</span>
                     </label>
                 </div>
+                <div>
+                    <span class="block text-sm font-medium text-gray-700 dark:text-gray-200">Paid by</span>
+                    <div class="flex flex-wrap gap-2 mt-1">
+                        @foreach($budgetEntry->itinerary->groupMembers as $member)
+                            <label class="inline-flex items-center">
+                                <input type="checkbox" name="paid_participants[]" value="{{ $member->id }}" @checked(in_array($member->id, old('paid_participants', $budgetEntry->paid_participants ?? []))) class="rounded">
+                                <span class="ml-1 text-sm">{{ $member->name }}</span>
+                            </label>
+                        @endforeach
+                    </div>
+                </div>
                 <script>
                     document.getElementById('toggle-all')?.addEventListener('change', function () {
                         document.querySelectorAll('input[name="participants[]"]').forEach(cb => cb.checked = this.checked);

--- a/resources/views/budgets/index.blade.php
+++ b/resources/views/budgets/index.blade.php
@@ -43,6 +43,17 @@
                             <span class="ml-1 text-sm">Include all</span>
                         </label>
                     </div>
+                    <div class="mt-2">
+                        <span class="block text-sm font-medium text-gray-700 dark:text-gray-200">Mark Paid</span>
+                        <div class="flex flex-wrap gap-2 mt-1">
+                            @foreach($itinerary->groupMembers as $member)
+                                <label class="inline-flex items-center">
+                                    <input type="checkbox" name="paid_participants[]" value="{{ $member->id }}" class="rounded">
+                                    <span class="ml-1 text-sm">{{ $member->name }}</span>
+                                </label>
+                            @endforeach
+                        </div>
+                    </div>
                     <script>
                         document.getElementById('toggle-all')?.addEventListener('change', function () {
                             document.querySelectorAll('input[name="participants[]"]').forEach(cb => cb.checked = this.checked);
@@ -99,7 +110,19 @@
                                                 @php
                                                     $members = $itinerary->groupMembers->whereIn('id', $entry->participants);
                                                 @endphp
-                                                <p class="text-xs text-gray-500">Shared with: {{ $members->pluck('name')->join(', ') }}</p>
+                                                <ul class="text-xs text-gray-500 space-y-1">
+                                                    @foreach($members as $member)
+                                                        <li>
+                                                            <form method="POST" action="{{ route('budgets.toggle-paid', [$entry->id, $member->id]) }}" class="inline">
+                                                                @csrf
+                                                                <label class="inline-flex items-center">
+                                                                    <input type="checkbox" onchange="this.form.submit()" @checked(in_array($member->id, $entry->paid_participants ?? [])) class="rounded">
+                                                                    <span class="ml-1">{{ $member->name }}</span>
+                                                                </label>
+                                                            </form>
+                                                        </li>
+                                                    @endforeach
+                                                </ul>
                                             @endif
                                         </td>
                                         <td class="px-4 py-2 text-right">PHP{{ number_format($entry->amount, 2) }}</td>

--- a/resources/views/budgets/show.blade.php
+++ b/resources/views/budgets/show.blade.php
@@ -15,7 +15,19 @@
             @php
                 $members = $budgetEntry->itinerary->groupMembers->whereIn('id', $budgetEntry->participants);
             @endphp
-            <p><strong>Shared with:</strong> {{ $members->pluck('name')->join(', ') }}</p>
+            <p><strong>Participants:</strong></p>
+            <ul class="list-disc ml-4">
+                @foreach($members as $member)
+                    <li>
+                        {{ $member->name }}
+                        @if(in_array($member->id, $budgetEntry->paid_participants ?? []))
+                            <span class="text-green-600">(paid)</span>
+                        @else
+                            <span class="text-red-600">(unpaid)</span>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
             <p><strong>Per Person:</strong> PHP{{ number_format($budgetEntry->amount / max(count($budgetEntry->participants),1), 2) }}</p>
         @endif
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ Route::middleware(['auth'])->group(function () {
         ->parameters(['budgets' => 'budgetEntry']);
     Route::get('budgets/{budgetEntry}/spent', [BudgetEntryController::class, 'editSpent'])->name('budgets.edit-spent');
     Route::patch('budgets/{budgetEntry}/spent', [BudgetEntryController::class, 'updateSpent'])->name('budgets.update-spent');
+    Route::post('budgets/{budgetEntry}/participants/{member}/toggle', [BudgetEntryController::class, 'togglePaid'])->name('budgets.toggle-paid');
     Route::resource('itineraries.bookings', BookingController::class)->shallow()->only(['store', 'update', 'destroy']);
 });
 


### PR DESCRIPTION
## Summary
- add `paid_participants` JSON column to budget entries
- allow budget entries to manage paid status for participants
- display and toggle paid participants in budget views

## Testing
- `php artisan test` (warnings: Failed to open stream: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_6891fd2c99448329bc6369c343de0e19