### PR TITLE
Paginate itinerary activities

### DIFF
--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -84,11 +84,15 @@ class ItineraryController extends Controller
      */
     public function show(string $id)
     {
-        $itinerary = Itinerary::with(['activities', 'groupMembers', 'budgetEntries', 'bookings'])
+        $itinerary = Itinerary::with(['groupMembers', 'budgetEntries', 'bookings'])
             ->where('user_id', Auth::id())
             ->findOrFail($id);
 
-        $primaryLocation = $itinerary->activities->first()->location ?? null;
+        $activities = $itinerary->activities()
+            ->orderBy('scheduled_at')
+            ->paginate(10);
+
+        $primaryLocation = $activities->first()->location ?? null;
         $averageBudget = null;
 
         if ($primaryLocation) {
@@ -101,7 +105,7 @@ class ItineraryController extends Controller
             })->avg('amount');
         }
 
-        return view('itineraries.show', compact('itinerary', 'averageBudget', 'primaryLocation'));
+        return view('itineraries.show', compact('itinerary', 'activities', 'averageBudget', 'primaryLocation'));
     }
 
     /**

--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -1,13 +1,14 @@
 @props(['activities'])
 
 @php
-    // Keep items in path order
-    $sorted = $activities->sortBy('scheduled_at');
+    $start = ($activities instanceof \Illuminate\Contracts\Pagination\Paginator)
+        ? $activities->firstItem()
+        : 1;
 @endphp
 
 <ul id="activity-list"
     class="mt-4 space-y-3 divide-y divide-gray-200 dark:divide-gray-700">
-@foreach ($sorted as $index => $activity)
+@foreach ($activities as $index => $activity)
     <li
         x-data="{ openDelete: false }"
         class="pt-3 first:pt-0 grid grid-cols-[auto_auto_1fr_auto] gap-3
@@ -18,7 +19,7 @@
         <span
             class="self-center flex h-6 w-6 items-center justify-center rounded-full
                    text-xs font-bold bg-primary text-white dark:bg-primary-light">
-            {{ $index + 1 }}
+            {{ $start + $index }}
         </span>
 
         {{-- Photo --}}
@@ -112,6 +113,12 @@
     </li>
 @endforeach
 </ul>
+
+@if ($activities instanceof \Illuminate\Contracts\Pagination\Paginator)
+    <div class="mt-4">
+        {{ $activities->links() }}
+    </div>
+@endif
 
 @push('scripts')
 <script>

--- a/resources/views/components/itinerary-card.blade.php
+++ b/resources/views/components/itinerary-card.blade.php
@@ -1,5 +1,5 @@
 {{-- Itinerary Card --}}
-@props(['itinerary', 'showActions' => true])
+@props(['itinerary', 'activities' => null, 'showActions' => true])
 
 {{-- One Alpine scope controls everything inside --}}
 <div x-data="{
@@ -13,6 +13,11 @@
         booking       : {}
     }" class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 space-y-4">
     @php
+        $activities = $activities ?? $itinerary->activities;
+        $mapActivities = $activities instanceof \Illuminate\Contracts\Pagination\Paginator
+            ? collect($activities->items())
+            : $activities;
+
         $photo = $itinerary->photo_path
             ? Storage::url($itinerary->photo_path)
             : asset('images/default-photo.svg');
@@ -118,8 +123,8 @@
     </div>
 
     <!-- ── Activities List ──────────────────────────────────────────── -->
-    @if($itinerary->activities->count())
-        <x-activity-list :activities="$itinerary->activities" />
+    @if($activities->count())
+        <x-activity-list :activities="$activities" />
     @else
         <p class="text-sm text-gray-400 italic">No activities yet.</p>
     @endif
@@ -149,7 +154,7 @@
 
     <!-- ── Map (hidden while any modal is open) ─────────────────────── -->
     <div x-show="!openActivityForm && !openEditModal && !openBookingForm && !openBookingEditModal" x-transition.opacity>
-        <x-itinerary-map :activities="$itinerary->activities" :bookings="$itinerary->bookings" />
+        <x-itinerary-map :activities="$mapActivities" :bookings="$itinerary->bookings" />
     </div>
 
 </div>

--- a/resources/views/itineraries/show.blade.php
+++ b/resources/views/itineraries/show.blade.php
@@ -6,7 +6,7 @@
     </x-slot>
 
     <div class="py-6 max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
-        <x-itinerary-card :itinerary="$itinerary" />
+        <x-itinerary-card :itinerary="$itinerary" :activities="$activities" />
         <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6">
             <h3 class="text-lg font-semibold text-gray-800 dark:text-white mb-4">Budget Overview</h3>
             @if($itinerary->budgetEntries->count())


### PR DESCRIPTION
## Summary
- Paginate activities in itinerary detail view
- Adjust itinerary and activity components to handle paginator and add pagination controls

## Testing
- `php artisan test` *(warnings: file_get_contents(/workspace/itinerary-planner/.env) failed)*

------
https://chatgpt.com/codex/tasks/task_e_6891fd2d3ecc8329bfa23e1b48269f46