### PR TITLE
Show validation errors for itinerary fields

### DIFF
--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -54,7 +54,7 @@ class ItineraryController extends Controller
  
     public function store(Request $request)
     {
-        $request->validate([
+        $validated = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
             'start_date' => 'required|date|after_or_equal:today',
@@ -62,19 +62,13 @@ class ItineraryController extends Controller
             'photo' => 'nullable|image|max:2048',
         ]);
 
-        $data = [
-            'user_id' => Auth::id(),
-            'title' => $request->title,
-            'description' => $request->description,
-            'start_date' => $request->start_date,
-            'end_date' => $request->end_date,
-        ];
+        $validated['user_id'] = Auth::id();
 
         if ($request->hasFile('photo')) {
-            $data['photo_path'] = $request->file('photo')->store('itineraries', 'public');
+            $validated['photo_path'] = $request->file('photo')->store('itineraries', 'public');
         }
 
-        Itinerary::create($data);
+        Itinerary::create($validated);
 
         return redirect()->route('dashboard')->with('success', 'Itinerary created.');
     }

--- a/resources/views/itineraries/create.blade.php
+++ b/resources/views/itineraries/create.blade.php
@@ -17,26 +17,30 @@
 
             <div class="mb-4">
                 <label for="title" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Title <span class="text-red-500">*</span></label>
-                <input type="text" name="title" id="title" required
+                <input type="text" name="title" id="title" required value="{{ old('title') }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+                <x-input-error :messages="$errors->get('title')" class="mt-2" />
             </div>
 
             <div class="mb-4">
                 <label for="description" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Description</label>
                 <textarea name="description" id="description"
-                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white"></textarea>
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white">{{ old('description') }}</textarea>
+                <x-input-error :messages="$errors->get('description')" class="mt-2" />
             </div>
 
             <div class="mb-4">
                 <label for="start_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Start Date <span class="text-red-500">*</span></label>
-                <input type="date" name="start_date" id="start_date" required
+                <input type="date" name="start_date" id="start_date" required value="{{ old('start_date') }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+                <x-input-error :messages="$errors->get('start_date')" class="mt-2" />
             </div>
 
             <div class="mb-4">
                 <label for="end_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">End Date <span class="text-red-500">*</span></label>
-            <input type="date" name="end_date" id="end_date" required
+            <input type="date" name="end_date" id="end_date" required value="{{ old('end_date') }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+                <x-input-error :messages="$errors->get('end_date')" class="mt-2" />
             </div>
 
             <div class="mb-4">

--- a/resources/views/itineraries/edit.blade.php
+++ b/resources/views/itineraries/edit.blade.php
@@ -14,23 +14,27 @@
                 <label for="title" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Title <span class="text-red-500">*</span></label>
                 <input type="text" name="title" id="title" required value="{{ old('title', $itinerary->title) }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+                <x-input-error :messages="$errors->get('title')" class="mt-2" />
             </div>
 
             <div class="mb-4">
                 <label for="description" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Description</label>
                 <textarea name="description" id="description" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white">{{ old('description', $itinerary->description) }}</textarea>
+                <x-input-error :messages="$errors->get('description')" class="mt-2" />
             </div>
 
             <div class="mb-4">
                 <label for="start_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">Start Date <span class="text-red-500">*</span></label>
                 <input type="date" name="start_date" id="start_date" required value="{{ old('start_date', $itinerary->start_date?->format('Y-m-d')) }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+                <x-input-error :messages="$errors->get('start_date')" class="mt-2" />
             </div>
 
             <div class="mb-4">
                 <label for="end_date" class="block font-medium text-sm text-gray-700 dark:text-gray-200">End Date <span class="text-red-500">*</span></label>
             <input type="date" name="end_date" id="end_date" required value="{{ old('end_date', $itinerary->end_date?->format('Y-m-d')) }}"
                     class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-gray-900 dark:text-white" />
+                <x-input-error :messages="$errors->get('end_date')" class="mt-2" />
             </div>
 
             <div class="mb-4">


### PR DESCRIPTION
## Summary
- show validation messages next to itinerary form fields
- retain previous input when validation fails
- validate incoming data before storing itineraries

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689209f2e5c08329b20e32ee130937e7