### PR TITLE
refactor: extract theme toggle script

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,5 @@
 import './bootstrap';
+import './theme-toggle';
 
 import Alpine from 'alpinejs';
 

--- a/resources/js/theme-toggle.js
+++ b/resources/js/theme-toggle.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('button[id^="theme-toggle-"]').forEach((button) => {
+        const thumb = document.getElementById(`${button.id}-thumb`);
+        if (!thumb) return;
+
+        const applyTheme = (isDark) => {
+            document.documentElement.classList.toggle('dark', isDark);
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            thumb.classList.toggle('translate-x-6', isDark);
+        };
+
+        let isDark = localStorage.getItem('theme') === 'dark';
+        applyTheme(isDark);
+
+        button.addEventListener('click', () => {
+            isDark = !isDark;
+            applyTheme(isDark);
+            document.dispatchEvent(new Event('theme-changed'));
+        });
+    });
+});

--- a/resources/views/components/theme-toggle.blade.php
+++ b/resources/views/components/theme-toggle.blade.php
@@ -8,25 +8,3 @@
     <span class="absolute right-1 text-gray-200 text-sm">🌙</span>
     <span id="{{ $thumbId }}" class="inline-block h-6 w-6 transform rounded-full bg-white shadow transition"></span>
 </button>
-
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        const button = document.getElementById(@js($toggleId));
-        const thumb = document.getElementById(@js($thumbId));
-
-        function applyTheme(isDark) {
-            document.documentElement.classList.toggle('dark', isDark);
-            localStorage.setItem('theme', isDark ? 'dark' : 'light');
-            thumb.classList.toggle('translate-x-6', isDark);
-        }
-
-        let isDark = localStorage.getItem('theme') === 'dark';
-        applyTheme(isDark);
-
-        button.addEventListener('click', () => {
-            isDark = !isDark;
-            applyTheme(isDark);
-            document.dispatchEvent(new Event('theme-changed'));
-        });
-    });
-</script>


### PR DESCRIPTION
## Summary
- move theme toggle JS into its own module and import in app.js
- remove inline script from Blade component

## Testing
- `npm run build`
- `php artisan test` *(fails: file_get_contents(/workspace/itinerary-planner/.env): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_689209f3d8f483298da2aae174cffa66