### PR TITLE
Add skip link for main content

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -27,6 +27,7 @@
 </head>
 
 <body class="font-sans antialiased">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:outline-none focus:ring">Skip to main content</a>
     <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
         @include('layouts.navigation')
 
@@ -40,7 +41,7 @@
         @endisset
 
         <!-- Page Content -->
-        <main>
+        <main id="main-content">
             {{ $slot }}
         </main>
         @if (session('success'))


### PR DESCRIPTION
## Summary
- add a visually hidden "Skip to main content" link for keyboard users
- mark the main element as the link target

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689209f54c348329932de3fd9d73953c