### PR TITLE
Remove redundant auth route group

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -40,12 +40,4 @@ Route::middleware(['auth'])->group(function () {
     Route::resource('itineraries.bookings', BookingController::class)->shallow()->only(['store', 'update', 'destroy']);
 });
 
-Route::middleware(['auth'])->group(function () {
-    Route::get('/itineraries/create', [ItineraryController::class, 'create'])->name('itineraries.create');
-    Route::post('/itineraries', [ItineraryController::class, 'store'])->name('itineraries.store');
-    // web.php
-    Route::post('/activities', [ActivityController::class, 'store'])->name('activities.store');
-    Route::resource('activities', controller: ActivityController::class);
-});
-
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- drop duplicate authenticated route group for itineraries and activities

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68921acc24188329829d0f0a762c637b