### PR TITLE
refactor: extract validation into form requests

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\StoreActivityRequest;
+use App\Http\Requests\UpdateActivityRequest;
 use App\Models\Activity;
 use App\Models\BudgetEntry;
 use Illuminate\Support\Facades\Auth;
-use App\Models\Itinerary;
 class ActivityController extends Controller
 {
     protected $fillable = ['title', 'note', 'scheduled_at', 'location', 'latitude', 'longitude', 'photo_path', 'itinerary_id'];
@@ -30,25 +30,8 @@ class ActivityController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreActivityRequest $request)
     {
-        $itinerary = Itinerary::where('user_id', Auth::id())
-            ->findOrFail($request->itinerary_id);
-
-        $request->validate([
-            'itinerary_id' => 'required|exists:itineraries,id',
-            'title' => 'required|string|max:255',
-            'location' => 'nullable|string|max:255',
-            'budget' => 'nullable|numeric|min:0',
-            'attire_color' => 'nullable|string|max:255',
-            'attire_note' => 'nullable|string|max:255',
-            'note' => 'nullable|string',
-            'scheduled_at' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
-            'latitude' => 'nullable|numeric',
-            'longitude' => 'nullable|numeric',
-            'photo' => 'nullable|image|max:2048',
-        ]);
-
         $data = [
             'itinerary_id' => $request->itinerary_id,
             'title' => $request->title,
@@ -101,26 +84,13 @@ class ActivityController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Activity $activity)
+    public function update(UpdateActivityRequest $request, Activity $activity)
     {
         if ($activity->itinerary->user_id !== Auth::id()) {
             abort(403);
         }
 
-        $itinerary = $activity->itinerary;
-
-        $validated = $request->validate([
-            'title'        => 'required|string|max:255',
-            'location'     => 'nullable|string|max:255',
-            'budget'       => 'nullable|numeric|min:0',
-            'attire_color' => 'nullable|string|max:255',
-            'attire_note'  => 'nullable|string|max:255',
-            'scheduled_at' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
-            'note'         => 'nullable|string',
-            'latitude'     => 'nullable|numeric',
-            'longitude'    => 'nullable|numeric',
-            'photo'        => 'nullable|image|max:2048',
-        ]);
+        $validated = $request->validated();
 
         if ($request->hasFile('photo')) {
             $validated['photo_path'] = $request->file('photo')->store('activities', 'public');

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -2,28 +2,15 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\StoreBookingRequest;
+use App\Http\Requests\UpdateBookingRequest;
 use App\Models\Booking;
-use App\Models\Itinerary;
 use Illuminate\Support\Facades\Auth;
 
 class BookingController extends Controller
 {
-    public function store(Request $request)
+    public function store(StoreBookingRequest $request)
     {
-        $itinerary = Itinerary::where('user_id', Auth::id())
-            ->findOrFail($request->itinerary_id);
-
-        $request->validate([
-            'itinerary_id' => 'required|exists:itineraries,id',
-            'place' => 'required|string|max:255',
-            'location' => 'nullable|string|max:255',
-            'check_in' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
-            'check_out' => ['required', 'date', 'after_or_equal:check_in', 'before_or_equal:' . $itinerary->end_date],
-            'latitude' => 'nullable|numeric',
-            'longitude' => 'nullable|numeric',
-        ]);
-
         Booking::create([
             'itinerary_id' => $request->itinerary_id,
             'place' => $request->place,
@@ -37,22 +24,13 @@ class BookingController extends Controller
         return redirect()->back()->with('success', 'Booking added.');
     }
 
-    public function update(Request $request, Booking $booking)
+    public function update(UpdateBookingRequest $request, Booking $booking)
     {
         if ($booking->itinerary->user_id !== Auth::id()) {
             abort(403);
         }
 
-        $itinerary = $booking->itinerary;
-
-        $validated = $request->validate([
-            'place' => 'required|string|max:255',
-            'location' => 'nullable|string|max:255',
-            'check_in' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
-            'check_out' => ['required', 'date', 'after_or_equal:check_in', 'before_or_equal:' . $itinerary->end_date],
-            'latitude' => 'nullable|numeric',
-            'longitude' => 'nullable|numeric',
-        ]);
+        $validated = $request->validated();
 
         $booking->update($validated);
 

--- a/app/Http/Controllers/GroupMemberController.php
+++ b/app/Http/Controllers/GroupMemberController.php
@@ -1,23 +1,17 @@
 <?php
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\StoreGroupMemberRequest;
+use App\Http\Requests\UpdateGroupMemberRequest;
 use App\Models\GroupMember;
 use App\Models\Itinerary;
 use Illuminate\Support\Facades\Auth;
 
 class GroupMemberController extends Controller
 {
-    public function store(Request $request)
+    public function store(StoreGroupMemberRequest $request)
     {
-        $itinerary = Itinerary::where('user_id', Auth::id())->findOrFail($request->itinerary_id);
-
-        $validated = $request->validate([
-            'itinerary_id' => 'required|exists:itineraries,id',
-            'name' => 'required|string|max:255',
-            'notes' => 'nullable|string',
-            'photo' => 'nullable|image|max:2048',
-        ]);
+        $validated = $request->validated();
 
         if ($request->hasFile('photo')) {
             $validated['photo_path'] = $request->file('photo')->store('group_members', 'public');
@@ -28,17 +22,13 @@ class GroupMemberController extends Controller
         return back()->with('success', 'Group member added.');
     }
 
-    public function update(Request $request, GroupMember $groupMember)
+    public function update(UpdateGroupMemberRequest $request, GroupMember $groupMember)
     {
         if ($groupMember->itinerary->user_id !== Auth::id()) {
             abort(403);
         }
 
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
-            'notes' => 'nullable|string',
-            'photo' => 'nullable|image|max:2048',
-        ]);
+        $validated = $request->validated();
 
         if ($request->hasFile('photo')) {
             $validated['photo_path'] = $request->file('photo')->store('group_members', 'public');

--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\StoreItineraryRequest;
+use App\Http\Requests\UpdateItineraryRequest;
 use App\Models\Itinerary;
 use App\Models\BudgetEntry;
 use Illuminate\Support\Facades\Auth;
@@ -52,15 +54,9 @@ class ItineraryController extends Controller
      * Store a newly created resource in storage.
      */
  
-    public function store(Request $request)
+    public function store(StoreItineraryRequest $request)
     {
-        $validated = $request->validate([
-            'title' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'start_date' => 'required|date|after_or_equal:today',
-            'end_date' => 'required|date|after_or_equal:start_date',
-            'photo' => 'nullable|image|max:2048',
-        ]);
+        $validated = $request->validated();
 
         $validated['user_id'] = Auth::id();
 
@@ -114,17 +110,11 @@ class ItineraryController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(UpdateItineraryRequest $request, string $id)
     {
         $itinerary = Itinerary::where('user_id', Auth::id())->findOrFail($id);
 
-        $validated = $request->validate([
-            'title' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'start_date' => 'required|date|after_or_equal:today',
-            'end_date' => 'required|date|after_or_equal:start_date',
-            'photo' => 'nullable|image|max:2048',
-        ]);
+        $validated = $request->validated();
 
         if ($request->hasFile('photo')) {
             $validated['photo_path'] = $request->file('photo')->store('itineraries', 'public');

--- a/app/Http/Requests/StoreActivityRequest.php
+++ b/app/Http/Requests/StoreActivityRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Itinerary;
+use Illuminate\Support\Facades\Auth;
+
+class StoreActivityRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        $itinerary = Itinerary::where('user_id', Auth::id())
+            ->findOrFail($this->itinerary_id);
+
+        return [
+            'itinerary_id' => 'required|exists:itineraries,id',
+            'title' => 'required|string|max:255',
+            'location' => 'nullable|string|max:255',
+            'budget' => 'nullable|numeric|min:0',
+            'attire_color' => 'nullable|string|max:255',
+            'attire_note' => 'nullable|string|max:255',
+            'note' => 'nullable|string',
+            'scheduled_at' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+            'photo' => 'nullable|image|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreBookingRequest.php
+++ b/app/Http/Requests/StoreBookingRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Itinerary;
+use Illuminate\Support\Facades\Auth;
+
+class StoreBookingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $itinerary = Itinerary::where('user_id', Auth::id())
+            ->findOrFail($this->itinerary_id);
+
+        return [
+            'itinerary_id' => 'required|exists:itineraries,id',
+            'place' => 'required|string|max:255',
+            'location' => 'nullable|string|max:255',
+            'check_in' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
+            'check_out' => ['required', 'date', 'after_or_equal:check_in', 'before_or_equal:' . $itinerary->end_date],
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreBudgetEntryRequest.php
+++ b/app/Http/Requests/StoreBudgetEntryRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Itinerary;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class StoreBudgetEntryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $itinerary = Itinerary::where('user_id', Auth::id())
+            ->with('groupMembers')
+            ->findOrFail($this->itinerary_id);
+
+        return [
+            'itinerary_id' => 'required|exists:itineraries,id',
+            'description' => 'required|string|max:255',
+            'amount' => 'required|numeric',
+            'entry_date' => 'required|date',
+            'category' => 'nullable|string|max:255',
+            'participants' => 'array|nullable',
+            'participants.*' => [
+                'integer',
+                Rule::exists('group_members', 'id')->where('itinerary_id', $itinerary->id),
+            ],
+            'paid_participants' => 'array|nullable',
+            'paid_participants.*' => [
+                'integer',
+                Rule::exists('group_members', 'id')->where('itinerary_id', $itinerary->id),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreGroupMemberRequest.php
+++ b/app/Http/Requests/StoreGroupMemberRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Itinerary;
+use Illuminate\Support\Facades\Auth;
+
+class StoreGroupMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        Itinerary::where('user_id', Auth::id())->findOrFail($this->itinerary_id);
+
+        return [
+            'itinerary_id' => 'required|exists:itineraries,id',
+            'name' => 'required|string|max:255',
+            'notes' => 'nullable|string',
+            'photo' => 'nullable|image|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreItineraryRequest.php
+++ b/app/Http/Requests/StoreItineraryRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreItineraryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'start_date' => 'required|date|after_or_equal:today',
+            'end_date' => 'required|date|after_or_equal:start_date',
+            'photo' => 'nullable|image|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateActivityRequest.php
+++ b/app/Http/Requests/UpdateActivityRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateActivityRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        $activity = $this->route('activity');
+        $itinerary = $activity->itinerary;
+
+        return [
+            'title' => 'required|string|max:255',
+            'location' => 'nullable|string|max:255',
+            'budget' => 'nullable|numeric|min:0',
+            'attire_color' => 'nullable|string|max:255',
+            'attire_note' => 'nullable|string|max:255',
+            'scheduled_at' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
+            'note' => 'nullable|string',
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+            'photo' => 'nullable|image|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateBookingRequest.php
+++ b/app/Http/Requests/UpdateBookingRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateBookingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $booking = $this->route('booking');
+        $itinerary = $booking->itinerary;
+
+        return [
+            'place' => 'required|string|max:255',
+            'location' => 'nullable|string|max:255',
+            'check_in' => ['required', 'date', 'after_or_equal:' . $itinerary->start_date, 'before_or_equal:' . $itinerary->end_date],
+            'check_out' => ['required', 'date', 'after_or_equal:check_in', 'before_or_equal:' . $itinerary->end_date],
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateBudgetEntryRequest.php
+++ b/app/Http/Requests/UpdateBudgetEntryRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateBudgetEntryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $budgetEntry = $this->route('budgetEntry');
+        $itineraryId = $budgetEntry->itinerary->id;
+
+        return [
+            'description' => 'required|string|max:255',
+            'amount' => 'required|numeric',
+            'entry_date' => 'required|date',
+            'category' => 'nullable|string|max:255',
+            'participants' => 'array|nullable',
+            'participants.*' => [
+                'integer',
+                Rule::exists('group_members', 'id')->where('itinerary_id', $itineraryId),
+            ],
+            'paid_participants' => 'array|nullable',
+            'paid_participants.*' => [
+                'integer',
+                Rule::exists('group_members', 'id')->where('itinerary_id', $itineraryId),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateGroupMemberRequest.php
+++ b/app/Http/Requests/UpdateGroupMemberRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateGroupMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'notes' => 'nullable|string',
+            'photo' => 'nullable|image|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateItineraryRequest.php
+++ b/app/Http/Requests/UpdateItineraryRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateItineraryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'start_date' => 'required|date|after_or_equal:today',
+            'end_date' => 'required|date|after_or_equal:start_date',
+            'photo' => 'nullable|image|max:2048',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add Store*/Update* FormRequest classes for activities, budget entries, bookings, group members, and itineraries
- update controllers to use new FormRequests instead of inline validation

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68921adfd64883298dac74b8c914e36e