### PR TITLE
feat: add reusable confirm dialog component

### DIFF
--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -10,7 +10,6 @@
     class="mt-4 space-y-3 divide-y divide-gray-200 dark:divide-gray-700">
 @foreach ($activities as $index => $activity)
     <li
-        x-data="{ openDelete: false }"
         class="pt-3 first:pt-0 grid grid-cols-[auto_auto_1fr_auto] gap-3
                hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition"
         data-marker-id="marker-{{ $activity->id }}"
@@ -93,31 +92,24 @@
                 </button>
 
                 {{-- Delete --}}
-                <button @click="openDelete = true"
+                <button @click="$dispatch('open-modal', 'delete-activity-{{ $activity->id }}')"
                         class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs font-medium">
                     Delete
                 </button>
-                <div x-show="openDelete" x-cloak x-transition.opacity.scale.80
-                     class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-                    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
-                        <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">Confirm Delete</h2>
-                        <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
-                            Are you sure you want to delete <span class="font-semibold">{{ $activity->title }}</span>
-                            scheduled for {{ \Carbon\Carbon::parse($activity->scheduled_at)->format('M j, g:i A') }}@if($activity->location)
-                                at {{ $activity->location }}@endif?
-                            This action cannot be undone.
-                        </p>
-                        <div class="flex justify-end gap-3">
-                            <button @click="openDelete = false"
-                                    class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
-                            <form method="POST" action="{{ route('activities.destroy', $activity->id) }}">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">Delete</button>
-                            </form>
-                        </div>
-                    </div>
-                </div>
+                <x-confirm-dialog name="delete-activity-{{ $activity->id }}" title="Confirm Delete">
+                    <x-slot name="message">
+                        Are you sure you want to delete <span class="font-semibold">{{ $activity->title }}</span>
+                        scheduled for {{ \Carbon\Carbon::parse($activity->scheduled_at)->format('M j, g:i A') }}@if($activity->location)
+                            at {{ $activity->location }}@endif? This action cannot be undone.
+                    </x-slot>
+                    <x-slot name="confirm">
+                        <form method="POST" action="{{ route('activities.destroy', $activity->id) }}">
+                            @csrf
+                            @method('DELETE')
+                            <x-danger-button>Delete</x-danger-button>
+                        </form>
+                    </x-slot>
+                </x-confirm-dialog>
             </div>
         </div>
     </li>

--- a/resources/views/components/booking-list.blade.php
+++ b/resources/views/components/booking-list.blade.php
@@ -1,7 +1,7 @@
 @props(['bookings'])
 <ul id="booking-list" class="mt-4 space-y-3 divide-y divide-gray-200 dark:divide-gray-700">
     @foreach($bookings as $booking)
-        <li x-data="{ openDelete: false }" class="pt-3 first:pt-0 flex justify-between items-start gap-3 hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition" data-marker-id="booking-{{ $booking->id }}">
+        <li class="pt-3 first:pt-0 flex justify-between items-start gap-3 hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition" data-marker-id="booking-{{ $booking->id }}">
             <div class="min-w-0">
                 <p class="text-sm font-medium text-gray-800 dark:text-white">{{ $booking->place }}</p>
                 <p class="text-xs text-gray-500 dark:text-gray-400">
@@ -13,24 +13,19 @@
             </div>
             <div class="flex items-center gap-1">
                 <button type="button" @click.prevent.stop="booking = {{ $booking->toJson() }}; openBookingEditModal = true; $dispatch('open-modal', { detail: 'edit-booking-{{ $booking->itinerary_id }}' })" class="inline-flex items-center px-2 py-1 bg-primary hover:bg-primary-dark text-white rounded text-xs font-medium">Edit</button>
-                <button @click="openDelete = true" class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs font-medium">Delete</button>
-                <div x-show="openDelete" x-cloak x-transition.opacity.scale.80 class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-                    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
-                        <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">Confirm Delete</h2>
-                        <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
-                            Are you sure you want to delete <span class="font-semibold">{{ $booking->place }}</span>?
-                            This action cannot be undone.
-                        </p>
-                        <div class="flex justify-end gap-3">
-                            <button @click="openDelete = false" class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
-                            <form method="POST" action="{{ route('bookings.destroy', $booking->id) }}">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">Delete</button>
-                            </form>
-                        </div>
-                    </div>
-                </div>
+                <button @click="$dispatch('open-modal', 'delete-booking-{{ $booking->id }}')" class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs font-medium">Delete</button>
+                <x-confirm-dialog name="delete-booking-{{ $booking->id }}" title="Confirm Delete">
+                    <x-slot name="message">
+                        Are you sure you want to delete <span class="font-semibold">{{ $booking->place }}</span>? This action cannot be undone.
+                    </x-slot>
+                    <x-slot name="confirm">
+                        <form method="POST" action="{{ route('bookings.destroy', $booking->id) }}">
+                            @csrf
+                            @method('DELETE')
+                            <x-danger-button>Delete</x-danger-button>
+                        </form>
+                    </x-slot>
+                </x-confirm-dialog>
             </div>
         </li>
     @endforeach

--- a/resources/views/components/confirm-dialog.blade.php
+++ b/resources/views/components/confirm-dialog.blade.php
@@ -1,0 +1,14 @@
+@props(['name', 'title', 'message' => null])
+
+<x-modal :name="$name" focusable>
+    <div class="p-6">
+        <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">{{ $title }}</h2>
+        <div class="text-sm text-gray-600 dark:text-gray-300 mb-4">
+            {{ $message ?? $slot }}
+        </div>
+        <div class="flex justify-end gap-3">
+            <x-secondary-button x-on:click="$dispatch('close')">Cancel</x-secondary-button>
+            {{ $confirm }}
+        </div>
+    </div>
+</x-modal>

--- a/resources/views/components/group-member-list.blade.php
+++ b/resources/views/components/group-member-list.blade.php
@@ -6,7 +6,7 @@
                 ? Storage::url($member->photo_path)
                 : asset('images/default-photo.svg');
         @endphp
-        <li x-data="{ openEdit: false, openDelete: false }" class="flex items-center justify-between bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
+        <li x-data="{ openEdit: false }" class="flex items-center justify-between bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
             <div class="flex items-center gap-3">
                 <img src="{{ $photo }}" alt="{{ $member->name }}" class="w-10 h-10 rounded-full object-cover border-2 border-gray-300 dark:border-gray-600">
                 <div>
@@ -21,7 +21,7 @@
                     class="inline-flex items-center px-2 py-1 bg-primary hover:bg-primary-dark text-white rounded text-xs">
                     Edit
                 </button>
-                <button @click="openDelete = true"
+                <button @click="$dispatch('open-modal', 'delete-member-{{ $member->id }}')"
                     class="inline-flex items-center px-2 py-1 bg-red-600 hover:bg-red-700 text-white rounded text-xs">
                     Delete
                 </button>
@@ -54,22 +54,18 @@
                 </div>
             </div>
 
-            <div x-show="openDelete" x-cloak x-transition.opacity.scale.80 class="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-                <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-sm">
-                    <h2 class="text-lg font-medium text-gray-800 dark:text-white mb-2">Confirm Delete</h2>
-                    <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
-                        Are you sure you want to delete <span class="font-semibold">{{ $member->name }}</span>? This action cannot be undone.
-                    </p>
-                    <div class="flex justify-end gap-3">
-                        <button @click="openDelete = false" class="px-4 py-2 bg-gray-300 dark:bg-gray-700 text-gray-800 dark:text-white rounded">Cancel</button>
-                        <form method="POST" action="{{ route('group-members.destroy', $member->id) }}">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded">Delete</button>
-                        </form>
-                    </div>
-                </div>
-            </div>
+            <x-confirm-dialog name="delete-member-{{ $member->id }}" title="Confirm Delete">
+                <x-slot name="message">
+                    Are you sure you want to delete <span class="font-semibold">{{ $member->name }}</span>? This action cannot be undone.
+                </x-slot>
+                <x-slot name="confirm">
+                    <form method="POST" action="{{ route('group-members.destroy', $member->id) }}">
+                        @csrf
+                        @method('DELETE')
+                        <x-danger-button>Delete</x-danger-button>
+                    </form>
+                </x-slot>
+            </x-confirm-dialog>
         </li>
     @endforeach
 </ul>


### PR DESCRIPTION
## Summary
- add `x-confirm-dialog` component wrapping `x-modal`
- replace inline delete modals in activity, booking, and group member lists
- standardize modal styling via existing button components and shared markup

## Testing
- `npm run build`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68921be86d4883298bd0eaf54725fb35