### PR TITLE
Add policies and authorization

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -103,9 +103,7 @@ class ActivityController extends Controller
      */
     public function update(Request $request, Activity $activity)
     {
-        if ($activity->itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $activity);
 
         $itinerary = $activity->itinerary;
 
@@ -148,9 +146,7 @@ class ActivityController extends Controller
      */
     public function destroy(Activity $activity)
     {
-        if ($activity->itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('delete', $activity);
 
         $activity->budgetEntry()->delete();
         $activity->delete();

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -39,9 +39,7 @@ class BookingController extends Controller
 
     public function update(Request $request, Booking $booking)
     {
-        if ($booking->itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $booking);
 
         $itinerary = $booking->itinerary;
 
@@ -61,9 +59,7 @@ class BookingController extends Controller
 
     public function destroy(Booking $booking)
     {
-        if ($booking->itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('delete', $booking);
 
         $booking->delete();
 

--- a/app/Http/Controllers/BudgetEntryController.php
+++ b/app/Http/Controllers/BudgetEntryController.php
@@ -83,9 +83,7 @@ class BudgetEntryController extends Controller
      */
     public function show(BudgetEntry $budgetEntry)
     {
-        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('view', $budgetEntry);
 
         $budgetEntry->load('itinerary.groupMembers');
 
@@ -97,9 +95,7 @@ class BudgetEntryController extends Controller
      */
     public function edit(BudgetEntry $budgetEntry)
     {
-        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $budgetEntry);
 
         $budgetEntry->load('itinerary.groupMembers');
 
@@ -111,9 +107,7 @@ class BudgetEntryController extends Controller
      */
     public function update(Request $request, BudgetEntry $budgetEntry)
     {
-        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $budgetEntry);
 
         $validated = $request->validate([
             'description' => 'required|string|max:255',
@@ -145,9 +139,7 @@ class BudgetEntryController extends Controller
      */
     public function destroy(BudgetEntry $budgetEntry)
     {
-        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('delete', $budgetEntry);
 
         $budgetEntry->delete();
 
@@ -156,18 +148,14 @@ class BudgetEntryController extends Controller
 
     public function editSpent(BudgetEntry $budgetEntry)
     {
-        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $budgetEntry);
 
         return view('budgets.edit-spent', compact('budgetEntry'));
     }
 
     public function updateSpent(Request $request, BudgetEntry $budgetEntry)
     {
-        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $budgetEntry);
 
         $validated = $request->validate([
             'spent_amount' => 'required|numeric|min:0',
@@ -180,9 +168,7 @@ class BudgetEntryController extends Controller
 
     public function togglePaid(Request $request, BudgetEntry $budgetEntry, int $member)
     {
-        if (! $budgetEntry->itinerary || (int) $budgetEntry->itinerary->user_id !== (int) Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $budgetEntry);
 
         $paid = $budgetEntry->paid_participants ?? [];
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests, ValidatesRequests;
 }

--- a/app/Http/Controllers/GroupMemberController.php
+++ b/app/Http/Controllers/GroupMemberController.php
@@ -30,9 +30,7 @@ class GroupMemberController extends Controller
 
     public function update(Request $request, GroupMember $groupMember)
     {
-        if ($groupMember->itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('update', $groupMember);
 
         $validated = $request->validate([
             'name' => 'required|string|max:255',
@@ -51,9 +49,7 @@ class GroupMemberController extends Controller
 
     public function destroy(GroupMember $groupMember)
     {
-        if ($groupMember->itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('delete', $groupMember);
 
         $groupMember->delete();
 

--- a/app/Http/Controllers/ItineraryController.php
+++ b/app/Http/Controllers/ItineraryController.php
@@ -148,9 +148,7 @@ class ItineraryController extends Controller
 
     public function exportExcel(Itinerary $itinerary)
     {
-        if ($itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('view', $itinerary);
 
         $itinerary->load(['activities', 'groupMembers', 'bookings', 'budgetEntries']);
 
@@ -159,9 +157,7 @@ class ItineraryController extends Controller
 
     public function exportPdf(Itinerary $itinerary)
     {
-        if ($itinerary->user_id !== Auth::id()) {
-            abort(403);
-        }
+        $this->authorize('view', $itinerary);
 
         $itinerary->load(['activities', 'groupMembers', 'bookings', 'budgetEntries']);
 

--- a/app/Policies/ActivityPolicy.php
+++ b/app/Policies/ActivityPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Activity;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ActivityPolicy
+{
+    use HandlesAuthorization;
+
+    public function view(User $user, Activity $activity): bool
+    {
+        return $user->id === $activity->itinerary->user_id;
+    }
+
+    public function update(User $user, Activity $activity): bool
+    {
+        return $this->view($user, $activity);
+    }
+
+    public function delete(User $user, Activity $activity): bool
+    {
+        return $this->view($user, $activity);
+    }
+}

--- a/app/Policies/BookingPolicy.php
+++ b/app/Policies/BookingPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Booking;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class BookingPolicy
+{
+    use HandlesAuthorization;
+
+    public function view(User $user, Booking $booking): bool
+    {
+        return $user->id === $booking->itinerary->user_id;
+    }
+
+    public function update(User $user, Booking $booking): bool
+    {
+        return $this->view($user, $booking);
+    }
+
+    public function delete(User $user, Booking $booking): bool
+    {
+        return $this->view($user, $booking);
+    }
+}

--- a/app/Policies/BudgetEntryPolicy.php
+++ b/app/Policies/BudgetEntryPolicy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\BudgetEntry;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class BudgetEntryPolicy
+{
+    use HandlesAuthorization;
+
+    protected function owns(User $user, BudgetEntry $budgetEntry): bool
+    {
+        return $budgetEntry->itinerary && $budgetEntry->itinerary->user_id === $user->id;
+    }
+
+    public function view(User $user, BudgetEntry $budgetEntry): bool
+    {
+        return $this->owns($user, $budgetEntry);
+    }
+
+    public function update(User $user, BudgetEntry $budgetEntry): bool
+    {
+        return $this->owns($user, $budgetEntry);
+    }
+
+    public function delete(User $user, BudgetEntry $budgetEntry): bool
+    {
+        return $this->owns($user, $budgetEntry);
+    }
+}

--- a/app/Policies/GroupMemberPolicy.php
+++ b/app/Policies/GroupMemberPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\GroupMember;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class GroupMemberPolicy
+{
+    use HandlesAuthorization;
+
+    public function view(User $user, GroupMember $groupMember): bool
+    {
+        return $user->id === $groupMember->itinerary->user_id;
+    }
+
+    public function update(User $user, GroupMember $groupMember): bool
+    {
+        return $this->view($user, $groupMember);
+    }
+
+    public function delete(User $user, GroupMember $groupMember): bool
+    {
+        return $this->view($user, $groupMember);
+    }
+}

--- a/app/Policies/ItineraryPolicy.php
+++ b/app/Policies/ItineraryPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Itinerary;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ItineraryPolicy
+{
+    use HandlesAuthorization;
+
+    public function view(User $user, Itinerary $itinerary): bool
+    {
+        return $user->id === $itinerary->user_id;
+    }
+
+    public function update(User $user, Itinerary $itinerary): bool
+    {
+        return $this->view($user, $itinerary);
+    }
+
+    public function delete(User $user, Itinerary $itinerary): bool
+    {
+        return $this->view($user, $itinerary);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\{Activity, BudgetEntry, Booking, GroupMember, Itinerary};
+use App\Policies\{ActivityPolicy, BudgetEntryPolicy, BookingPolicy, GroupMemberPolicy, ItineraryPolicy};
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    protected $policies = [
+        Activity::class => ActivityPolicy::class,
+        BudgetEntry::class => BudgetEntryPolicy::class,
+        Booking::class => BookingPolicy::class,
+        GroupMember::class => GroupMemberPolicy::class,
+        Itinerary::class => ItineraryPolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}


### PR DESCRIPTION
## Summary
- add policies for activities, budget entries, bookings, group members and itineraries
- register policies in AuthServiceProvider and enable controller authorization
- replace manual abort(403) checks with `$this->authorize`

## Testing
- `php artisan test` *(fails: file_get_contents(/workspace/itinerary-planner/.env): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68921acd17ec832997169e5b60fcf9be