### PR TITLE
feat: add list item limiter

### DIFF
--- a/resources/views/components/activity-list.blade.php
+++ b/resources/views/components/activity-list.blade.php
@@ -4,17 +4,19 @@
     $start = ($activities instanceof \Illuminate\Contracts\Pagination\Paginator)
         ? $activities->firstItem()
         : 1;
+    $itemCount = count($activities);
 @endphp
-
-<ul id="activity-list"
-    class="mt-4 space-y-3 divide-y divide-gray-200 dark:divide-gray-700">
-@foreach ($activities as $index => $activity)
-    <li
-        x-data="{ openDelete: false }"
-        class="pt-3 first:pt-0 grid grid-cols-[auto_auto_1fr_auto] gap-3
-               hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition"
-        data-marker-id="marker-{{ $activity->id }}"
-    >
+<div x-data="{ limit: 5, count: {{ $itemCount }} }">
+    <ul id="activity-list"
+        class="mt-4 space-y-3 divide-y divide-gray-200 dark:divide-gray-700">
+    @foreach ($activities as $index => $activity)
+        <li
+            x-data="{ openDelete: false }"
+            x-show="{{ $index }} < limit"
+            class="pt-3 first:pt-0 grid grid-cols-[auto_auto_1fr_auto] gap-3
+                   hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition"
+            data-marker-id="marker-{{ $activity->id }}"
+        >
         {{-- Sequence bubble --}}
         <span
             class="self-center flex h-6 w-6 items-center justify-center rounded-full
@@ -120,9 +122,21 @@
                 </div>
             </div>
         </div>
-    </li>
-@endforeach
-</ul>
+        </li>
+    @endforeach
+    </ul>
+    <button
+        x-show="count > 5"
+        @click="limit = limit === 5 ? count : 5"
+        @keydown.enter.prevent="limit = limit === 5 ? count : 5"
+        @keydown.space.prevent="limit = limit === 5 ? count : 5"
+        :aria-expanded="limit > 5"
+        aria-controls="activity-list"
+        :aria-label="limit === 5 ? 'Show more activities' : 'Show less activities'"
+        class="mt-2 text-sm text-primary hover:underline">
+        <span x-text="limit === 5 ? 'Show more' : 'Show less'"></span>
+    </button>
+</div>
 
 @if ($activities instanceof \Illuminate\Contracts\Pagination\Paginator)
     <div class="mt-4">

--- a/resources/views/components/booking-list.blade.php
+++ b/resources/views/components/booking-list.blade.php
@@ -1,7 +1,9 @@
 @props(['bookings'])
+@php $itemCount = count($bookings); @endphp
+<div x-data="{ limit: 5, count: {{ $itemCount }} }">
 <ul id="booking-list" class="mt-4 space-y-3 divide-y divide-gray-200 dark:divide-gray-700">
-    @foreach($bookings as $booking)
-        <li x-data="{ openDelete: false }" class="pt-3 first:pt-0 flex justify-between items-start gap-3 hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition" data-marker-id="booking-{{ $booking->id }}">
+    @foreach($bookings as $index => $booking)
+        <li x-data="{ openDelete: false }" x-show="{{ $index }} < limit" class="pt-3 first:pt-0 flex justify-between items-start gap-3 hover:bg-gray-50 dark:hover:bg-gray-700/40 rounded-md px-3 py-2 transition" data-marker-id="booking-{{ $booking->id }}">
             <div class="min-w-0">
                 <p class="text-sm font-medium text-gray-800 dark:text-white">{{ $booking->place }}</p>
                 <p class="text-xs text-gray-500 dark:text-gray-400">
@@ -35,6 +37,18 @@
         </li>
     @endforeach
 </ul>
+<button
+    x-show="count > 5"
+    @click="limit = limit === 5 ? count : 5"
+    @keydown.enter.prevent="limit = limit === 5 ? count : 5"
+    @keydown.space.prevent="limit = limit === 5 ? count : 5"
+    :aria-expanded="limit > 5"
+    aria-controls="booking-list"
+    :aria-label="limit === 5 ? 'Show more bookings' : 'Show less bookings'"
+    class="mt-2 text-sm text-primary hover:underline">
+    <span x-text="limit === 5 ? 'Show more' : 'Show less'"></span>
+</button>
+</div>
 
 @push('scripts')
 <script>

--- a/resources/views/components/group-member-list.blade.php
+++ b/resources/views/components/group-member-list.blade.php
@@ -1,12 +1,14 @@
 @props(['members'])
-<ul class="mt-4 space-y-2">
+@php $itemCount = count($members); @endphp
+<div x-data="{ limit: 5, count: {{ $itemCount }} }">
+<ul class="mt-4 space-y-2" id="group-member-list">
     @foreach($members as $member)
         @php
             $photo = $member->photo_path
                 ? Storage::url($member->photo_path)
                 : asset('images/default-photo.svg');
         @endphp
-        <li x-data="{ openEdit: false, openDelete: false }" class="flex items-center justify-between bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
+        <li x-data="{ openEdit: false, openDelete: false }" x-show="{{ $loop->index }} < limit" class="flex items-center justify-between bg-gray-100 dark:bg-gray-700 rounded px-3 py-2">
             <div class="flex items-center gap-3">
                 <img src="{{ $photo }}" alt="{{ $member->name }}" class="w-10 h-10 rounded-full object-cover border-2 border-gray-300 dark:border-gray-600">
                 <div>
@@ -73,3 +75,15 @@
         </li>
     @endforeach
 </ul>
+<button
+    x-show="count > 5"
+    @click="limit = limit === 5 ? count : 5"
+    @keydown.enter.prevent="limit = limit === 5 ? count : 5"
+    @keydown.space.prevent="limit = limit === 5 ? count : 5"
+    :aria-expanded="limit > 5"
+    aria-controls="group-member-list"
+    :aria-label="limit === 5 ? 'Show more members' : 'Show less members'"
+    class="mt-2 text-sm text-primary hover:underline">
+    <span x-text="limit === 5 ? 'Show more' : 'Show less'"></span>
+</button>
+</div>


### PR DESCRIPTION
## Summary
- limit activity, booking, and member lists to five items by default
- add accessible show more/less toggles for each list

## Testing
- `npm run build`
- `composer test` (warnings: Failed to open stream .env)


------
https://chatgpt.com/codex/tasks/task_e_68921be918b08329be1f0f4ca7b03af3