### PR TITLE
Ensure modals overlay Leaflet maps

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.leaflet-pane,
+.leaflet-top,
+.leaflet-bottom {
+    z-index: 0 !important;
+}

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -46,7 +46,7 @@ $maxWidth = [
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
-    class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
+    class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-[2000]"
     style="display: {{ $show ? 'block' : 'none' }};"
 >
     <div


### PR DESCRIPTION
## Summary
- Elevate modal stacking context so overlays sit above Leaflet layers
- Force Leaflet panes to z-index 0 to keep map layers beneath UI

## Testing
- `npm run build`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68921be9a2dc8329aac153ce57e79a6c