### PR TITLE
Fix activity form store route

### DIFF
--- a/resources/views/activity/activity-form.blade.php
+++ b/resources/views/activity/activity-form.blade.php
@@ -19,7 +19,7 @@
     <form
         :action="activity.id
             ? ('/activities/' + activity.id)          /* PUT  → /activities/{id} */
-            : '{{ route('activities.store') }}'        /* POST → /activities      */"
+            : '{{ route('itineraries.activities.store', $itinerary->id) }}'        /* POST → /itineraries/{itinerary}/activities */"
         method="POST"
         enctype="multipart/form-data"
         class="space-y-6"


### PR DESCRIPTION
## Summary
- use `itineraries.activities.store` route for new activity form

## Testing
- `php artisan test` *(warnings: Failed to open stream: No such file or directory for .env)*

------
https://chatgpt.com/codex/tasks/task_e_6892cadfb57c832981d48ac9e7ab4997