### PR TITLE
Refactor activity budget to use budget entries

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -13,13 +13,14 @@ class Activity extends Model
         'location',
         'note',
         'scheduled_at',
-        'budget',
         'attire_color',
         'attire_note',
         'latitude',
         'longitude',
         'photo_path',
     ];
+
+    protected $appends = ['budget'];
 
     public function itinerary()
     {
@@ -31,4 +32,8 @@ class Activity extends Model
         return $this->hasOne(BudgetEntry::class);
     }
 
+    public function getBudgetAttribute()
+    {
+        return $this->budgetEntry->amount ?? null;
+    }
 }

--- a/app/Models/BudgetEntry.php
+++ b/app/Models/BudgetEntry.php
@@ -18,6 +18,8 @@ class BudgetEntry extends Model
         'paid_participants',
     ];
 
+    protected $touches = ['activity'];
+
     /**
      * Cast attributes to common types.
      */

--- a/database/migrations/2025_08_05_000000_remove_budget_from_activities_table.php
+++ b/database/migrations/2025_08_05_000000_remove_budget_from_activities_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropColumn('budget');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->decimal('budget', 8, 2)->nullable()->after('location');
+        });
+    }
+};

--- a/tests/Feature/ActivityBudgetTest.php
+++ b/tests/Feature/ActivityBudgetTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Activity;
+use App\Models\Itinerary;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ActivityBudgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_creates_budget_entry_and_sets_budget_via_accessor(): void
+    {
+        $user = User::factory()->create();
+        $itinerary = Itinerary::create([
+            'user_id' => $user->id,
+            'title' => 'Sample Trip',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addDay()->toDateString(),
+        ]);
+
+        $scheduled = now()->addHour();
+
+        $this->actingAs($user)->post(route('itineraries.activities.store', $itinerary->id), [
+            'itinerary_id' => $itinerary->id,
+            'title' => 'Hiking',
+            'location' => 'Mountain',
+            'budget' => 150,
+            'scheduled_at' => $scheduled->toDateTimeString(),
+        ]);
+
+        $activity = Activity::first();
+        $this->assertNotNull($activity->budgetEntry);
+        $this->assertEquals(150, $activity->budget);
+    }
+
+    public function test_update_changes_linked_budget_entry_amount(): void
+    {
+        $user = User::factory()->create();
+        $itinerary = Itinerary::create([
+            'user_id' => $user->id,
+            'title' => 'Sample Trip',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addDay()->toDateString(),
+        ]);
+
+        $activity = Activity::create([
+            'itinerary_id' => $itinerary->id,
+            'title' => 'Hiking',
+            'scheduled_at' => now()->addHour(),
+        ]);
+
+        $activity->budgetEntry()->create([
+            'itinerary_id' => $itinerary->id,
+            'description' => 'Hiking',
+            'amount' => 100,
+            'entry_date' => now()->toDateString(),
+            'category' => 'Activity',
+            'spent_amount' => 0,
+        ]);
+
+        $this->actingAs($user)->patch(route('activities.update', $activity->id), [
+            'title' => 'Hiking',
+            'location' => 'Mountain',
+            'budget' => 200,
+            'scheduled_at' => now()->addHour()->toDateTimeString(),
+        ]);
+
+        $this->assertEquals(200, $activity->budgetEntry->fresh()->amount);
+        $this->assertEquals(200, $activity->fresh()->budget);
+    }
+}


### PR DESCRIPTION
## Summary
- derive Activity budget from its related BudgetEntry via accessor
- drop legacy `budget` column from activities table
- update ActivityController to persist budgets only through BudgetEntry
- add feature tests for new budget handling

## Testing
- `vendor/bin/pint app/Models/Activity.php app/Models/BudgetEntry.php app/Http/Controllers/ActivityController.php database/migrations/2025_08_05_000000_remove_budget_from_activities_table.php tests/Feature/ActivityBudgetTest.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6892d7c03f148329bd5a31e27e65bd5b