### PR TITLE
Add casts for booking model and tests

### DIFF
--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -16,6 +16,19 @@ class Booking extends Model
         'longitude',
     ];
 
+    /**
+     * Cast attributes to common types.
+     */
+    protected function casts(): array
+    {
+        return [
+            'check_in' => 'date',
+            'check_out' => 'date',
+            'latitude' => 'float',
+            'longitude' => 'float',
+        ];
+    }
+
     public function itinerary()
     {
         return $this->belongsTo(Itinerary::class);

--- a/tests/Unit/BookingTest.php
+++ b/tests/Unit/BookingTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Booking;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class BookingTest extends TestCase
+{
+    public function test_casts_dates_and_coordinates(): void
+    {
+        $booking = new Booking([
+            'check_in' => '2024-05-10',
+            'check_out' => '2024-05-15',
+            'latitude' => '45.123',
+            'longitude' => '-123.456',
+        ]);
+
+        $this->assertInstanceOf(Carbon::class, $booking->check_in);
+        $this->assertInstanceOf(Carbon::class, $booking->check_out);
+        $this->assertIsFloat($booking->latitude);
+        $this->assertIsFloat($booking->longitude);
+        $this->assertSame(45.123, $booking->latitude);
+        $this->assertSame(-123.456, $booking->longitude);
+    }
+}
+


### PR DESCRIPTION
## Summary
- cast booking check-in/out dates and coordinates to proper types
- cover booking model casts with a unit test

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6892d7c14b1c8329a0b965b53b95e6a7