### PR TITLE
Ensure budget entries link to activities

### DIFF
--- a/database/migrations/2025_08_13_111714_add_activity_id_to_budget_entries_table.php
+++ b/database/migrations/2025_08_13_111714_add_activity_id_to_budget_entries_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('budget_entries', 'activity_id')) {
+            Schema::table('budget_entries', function (Blueprint $table) {
+                $table->foreignId('activity_id')->nullable()->constrained()->onDelete('cascade');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('budget_entries', 'activity_id')) {
+            Schema::table('budget_entries', function (Blueprint $table) {
+                $table->dropForeign(['activity_id']);
+                $table->dropColumn('activity_id');
+            });
+        }
+    }
+};

--- a/tests/Unit/ActivityCastTest.php
+++ b/tests/Unit/ActivityCastTest.php
@@ -28,10 +28,20 @@ class ActivityCastTest extends TestCase
             'itinerary_id' => $itinerary->id,
             'title' => 'Hiking',
             'scheduled_at' => '2024-01-01 10:00:00',
-            'budget' => '123.45',
             'latitude' => '10.1234567',
             'longitude' => '20.7654321',
-        ])->fresh();
+        ]);
+
+        $activity->budgetEntry()->create([
+            'itinerary_id' => $itinerary->id,
+            'description' => 'Hiking',
+            'amount' => 123.45,
+            'entry_date' => '2024-01-01',
+            'category' => 'Activity',
+            'spent_amount' => 0,
+        ]);
+
+        $activity->refresh();
 
         $this->assertInstanceOf(Carbon::class, $activity->scheduled_at);
         $this->assertSame('2024-01-01 10:00:00', $activity->scheduled_at->format('Y-m-d H:i:s'));


### PR DESCRIPTION
## Summary
- add migration that inserts missing activity_id column on budget entries
- adjust Activity cast test to create associated BudgetEntry

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689c738307a88329ab753a1d491a0fb6